### PR TITLE
rename result files from *.mfres.jld2 to *.iesopt.result.jld2

### DIFF
--- a/src/results/jld2.jl
+++ b/src/results/jld2.jl
@@ -62,7 +62,8 @@ function _save_results(model::JuMP.Model)
     # TODO: support multiple results (from MOA)
 
     # Make sure the path is valid.
-    filepath = normpath(_iesopt_config(model).paths.results, "$(_iesopt_config(model).names.scenario).mfres.jld2")
+    filepath =
+        normpath(_iesopt_config(model).paths.results, "$(_iesopt_config(model).names.scenario).iesopt.result.jld2")
     mkpath(dirname(filepath))
 
     # Write results.

--- a/src/utils/packing.jl
+++ b/src/utils/packing.jl
@@ -81,7 +81,7 @@ function pack(file::String; out::String="", method::Symbol=:auto, include_result
             elseif endswith(filename, ".iesopt.param.yaml")
                 push!(files, relpath(normpath(root, filename), root_path))
                 push!(info["files"]["parameters"], relpath(normpath(root, filename), root_path))
-            elseif endswith(filename, ".mfres.jld2") && include_results
+            elseif endswith(filename, ".iesopt.result.jld2") && include_results
                 push!(files, relpath(normpath(root, filename), root_path))
                 push!(info["files"]["results"], relpath(normpath(root, filename), root_path))
             else


### PR DESCRIPTION
This is still reference to the old MarketFlow name, we should get rid of, right?
Sorry, I did not use conventional commits yet.
Feel free to close if you are already working on this on a local branch.