### PR TITLE
add weigths to nodalbalance constraints to provide correct prices as duals

### DIFF
--- a/src/core/node/con_nodalbalance.jl
+++ b/src/core/node/con_nodalbalance.jl
@@ -116,14 +116,18 @@ function _node_con_nodalbalance!(node::Node)
             node.con.nodalbalance = @constraint(
                 model,
                 [t = _iesopt(model).model.T],
-                node.exp.injection[t] == 0,
+                _weight(model, t) * node.exp.injection[t] == 0,
                 base_name = _base_name(node, "nodalbalance"),
                 container = Array
             )
         else
             # Create all representatives.
             _repr = Dict(
-                t => @constraint(model, node.exp.injection[t] == 0, base_name = _base_name(node, "nodalbalance[$(t)]")) for t in _iesopt(model).model.T if _iesopt(model).model.snapshots[t].is_representative
+                t => @constraint(
+                    model,
+                    _weight(model, t) * node.exp.injection[t] == 0,
+                    base_name = _base_name(node, "nodalbalance[$(t)]")
+                ) for t in _iesopt(model).model.T if _iesopt(model).model.snapshots[t].is_representative
             )
 
             # Create all constraints, either as themselves or their representative.
@@ -137,14 +141,18 @@ function _node_con_nodalbalance!(node::Node)
             node.con.nodalbalance = @constraint(
                 model,
                 [t = _iesopt(model).model.T],
-                node.exp.injection[t] <= 0,
+                _weight(model, t) * node.exp.injection[t] <= 0,
                 base_name = _base_name(node, "nodalbalance"),
                 container = Array
             )
         else
             # Create all representatives.
             _repr = Dict(
-                t => @constraint(model, node.exp.injection[t] <= 0, base_name = _base_name(node, "nodalbalance[$(t)]")) for t in _iesopt(model).model.T if _iesopt(model).model.snapshots[t].is_representative
+                t => @constraint(
+                    model,
+                    _weight(model, t) * node.exp.injection[t] <= 0,
+                    base_name = _base_name(node, "nodalbalance[$(t)]")
+                ) for t in _iesopt(model).model.T if _iesopt(model).model.snapshots[t].is_representative
             )
 
             # Create all constraints, either as themselves or their representative.
@@ -158,14 +166,18 @@ function _node_con_nodalbalance!(node::Node)
             node.con.nodalbalance = @constraint(
                 model,
                 [t = _iesopt(model).model.T],
-                node.exp.injection[t] >= 0,
+                _weight(model, t) * node.exp.injection[t] >= 0,
                 base_name = _base_name(node, "nodalbalance"),
                 container = Array
             )
         else
             # Create all representatives.
             _repr = Dict(
-                t => @constraint(model, node.exp.injection[t] >= 0, base_name = _base_name(node, "nodalbalance[$(t)]")) for t in _iesopt(model).model.T if _iesopt(model).model.snapshots[t].is_representative
+                t => @constraint(
+                    model,
+                    _weight(model, t) * node.exp.injection[t] >= 0,
+                    base_name = _base_name(node, "nodalbalance[$(t)]")
+                ) for t in _iesopt(model).model.T if _iesopt(model).model.snapshots[t].is_representative
             )
 
             # Create all constraints, either as themselves or their representative.
@@ -180,7 +192,7 @@ function _node_con_nodalbalance!(node::Node)
         node.con.nodalbalance = @constraint(
             model,
             [t0 = begin_steps],
-            sum(node.exp.injection[t] for t in t0:(t0 - 1 + node.sum_window_size)) == 0,
+            sum(_weight(model, t) * node.exp.injection[t] for t in t0:(t0 - 1 + node.sum_window_size)) == 0,
             base_name = _base_name(node, "nodalbalance"),
             container = Array
         )


### PR DESCRIPTION
For `Node`s with state we multiply the injection with the corresponding weight in the nodal balance constraint.
We don't do this for nodes without state. So if our objective is in `EUR`, the power values of our carriers are e.g. in `MW` and our weight ω is in `h` then the duals of our nodal balance constraints will be in `EUR/(MW * ω * h)` instead of `EUR/MWh`.

This change multiplies all injection values in all nodal balance constraints with `ω`, so our duals will always have the unit `EUR/MWh`.
I'm not entirely sure if this has some unexpected implications, so I'm leaving this as a PR to review.