### PR TITLE
fix: accept Integer as weights in config

### DIFF
--- a/src/config/optimization.jl
+++ b/src/config/optimization.jl
@@ -83,11 +83,14 @@ function _ConfigSnapshots(config::Dict{String, Any})
         @warn "Detected precompilation... limiting Snapshot count" original = config["count"] new = count
     end
 
+    weight_config = get(config, "weights", nothing)
+    weights = weight_config isa Real ? float(weight_config) : weight_config
+
     return _ConfigSnapshots(
         count,
         get(config, "offset", 0),
         get(config, "names", nothing),
-        get(config, "weights", nothing),
+        weights,
         get(config, "representatives", nothing),
         get(config, "aggregate", nothing),
     )


### PR DESCRIPTION
If I set
```yaml
config:
  optimization:
    snapshots:
      weights: 1
```
in the IESopt config yaml, I get the following error:
```julia
┌ Error: Error(s) during model generation
│   debug = "not available"
│   number_of_errors = 1
│    = = = = = = = = = [ Error #1 ] = = = = = = = = =
│    MethodError: Cannot `convert` an object of type
│      Int64 to an object of type
│      Union{Float64, String}
│ 
│    Closest candidates are:
│      convert(::Type{T}, ::T) where T
│       @ Base Base.jl:84
│ 
│    Stacktrace:
│     [1] IESopt._ConfigSnapshots(count::Int64, offset::Int64, names::Nothing, weights::Int64, representatives::Nothing, aggregate::Nothing)
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\config\optimization.jl:9
│     [2] IESopt._ConfigSnapshots(config::Dict{String, Any})
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\config\optimization.jl:86
│     [3] IESopt._ConfigOptimization(config::Dict{String, Any})
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\config\optimization.jl:47
│     [4] IESopt._Config(model::JuMP.Model)
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\config\config.jl:45
│     [5] _parse_model!(model::JuMP.Model, filename::String, global_parameters::Dict{String, Any}; verbosity::Nothing)
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\parser.jl:11
│     [6] parse!(model::JuMP.Model, filename::String; verbosity::Nothing, kwargs::@Kwargs{weight::Int64})
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\IESopt.jl:511
│     [7] generate!(model::JuMP.Model, filename::String; verbosity::Nothing, kwargs::@Kwargs{weight::Int64})
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\IESopt.jl:325
│     [8] run(filename::String; verbosity::Nothing, kwargs::@Kwargs{weight::Int64})
│       @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\IESopt.jl:279
└ @ IESopt C:\Users\SchwabenederD\.julia\dev\IESopt\src\IESopt.jl:365
```
This change fixes this and also allows integers in the weigths config.