### PR TITLE
fix: rely on JuliaSyntax's tokenize instead of regex-based splitting of strings during conversion to expr

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IESopt"
 uuid = "ed3f0a38-8ad9-4cf8-877e-929e8d190fe9"
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/assets/examples/01_basic_single_node.iesopt.yaml
+++ b/src/assets/examples/01_basic_single_node.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     # This specifies the overall type of optimization problem. If using "LP" like here, no component can utilize
     # formulations that are of a "higher" class (e.g. MILP).

--- a/src/assets/examples/02_advanced_single_node.iesopt.yaml
+++ b/src/assets/examples/02_advanced_single_node.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/03_basic_two_nodes.iesopt.yaml
+++ b/src/assets/examples/03_basic_two_nodes.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/04_soft_constraints.iesopt.yaml
+++ b/src/assets/examples/04_soft_constraints.iesopt.yaml
@@ -17,7 +17,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/05_basic_two_nodes_1y.iesopt.yaml
+++ b/src/assets/examples/05_basic_two_nodes_1y.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/06_recursion_h2.iesopt.yaml
+++ b/src/assets/examples/06_recursion_h2.iesopt.yaml
@@ -6,7 +6,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/07_csv_filestorage.iesopt.yaml
+++ b/src/assets/examples/07_csv_filestorage.iesopt.yaml
@@ -63,8 +63,8 @@ components:
     conversion: 1 wind -> 1 electricity
     capacity: 10 out:electricity
     # Instead of cluttering our YAML with 8760 entries, we now just load it from a CSV. This is done by supplying the
-    # correct column (07_plant_wind_availability_factor) that can be found in the CSV (data) like so:
-    availability_factor: 07_plant_wind_availability_factor@data
+    # correct column (ex07_plant_wind_availability_factor) that can be found in the CSV (data) like so:
+    availability_factor: ex07_plant_wind_availability_factor@data
   
   plant_gas:
     type: Unit
@@ -78,14 +78,14 @@ components:
     carrier: electricity
     node_from: node1
     # Again, now loading from CSV.
-    value: 07_demand1_value@data
+    value: ex07_demand1_value@data
   
   demand2:
     type: Profile
     carrier: electricity
     node_from: node2
     # Again, now loading from CSV.
-    value: 07_demand2_value@data
+    value: ex07_demand2_value@data
 
   gas_grid:
     type: Node

--- a/src/assets/examples/07_csv_filestorage.iesopt.yaml
+++ b/src/assets/examples/07_csv_filestorage.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/08_basic_investment.iesopt.yaml
+++ b/src/assets/examples/08_basic_investment.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/08_basic_investment.iesopt.yaml
+++ b/src/assets/examples/08_basic_investment.iesopt.yaml
@@ -87,7 +87,7 @@ components:
     outputs: {electricity: elec}
     conversion: ~ -> 1 electricity
     capacity: 1 out:electricity
-    availability_factor: 08_pv@data
+    availability_factor: ex08_pv@data
   
   electrolysis:
     type: Unit
@@ -100,6 +100,6 @@ components:
     type: Profile
     carrier: h2
     node_from: h2_south
-    value: 08_demand@data
+    value: ex08_demand@data
 
   

--- a/src/assets/examples/09_csv_only.iesopt.yaml
+++ b/src/assets/examples/09_csv_only.iesopt.yaml
@@ -6,7 +6,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/10_basic_load_shedding.iesopt.yaml
+++ b/src/assets/examples/10_basic_load_shedding.iesopt.yaml
@@ -72,7 +72,7 @@ components:
     outputs: {electricity: elec}
     conversion: ~ -> 1 electricity
     capacity: 1 out:electricity
-    availability_factor: 08_pv@data
+    availability_factor: ex08_pv@data
   
   electrolysis:
     type: Unit
@@ -85,7 +85,7 @@ components:
     type: Profile
     carrier: h2
     node_from: h2_south
-    value: 08_demand@data
+    value: ex08_demand@data
 
   # This allows the "reducing demand" (load shedding) by introducing a Profile that covers the missing energy.
   shedding:

--- a/src/assets/examples/10_basic_load_shedding.iesopt.yaml
+++ b/src/assets/examples/10_basic_load_shedding.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/11_basic_unit_commitment.iesopt.yaml
+++ b/src/assets/examples/11_basic_unit_commitment.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/12_incremental_efficiency.iesopt.yaml
+++ b/src/assets/examples/12_incremental_efficiency.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/15_varying_efficiency.iesopt.yaml
+++ b/src/assets/examples/15_varying_efficiency.iesopt.yaml
@@ -25,7 +25,7 @@ components:
   heatpump:
     type: Unit
     capacity: 100 out:heat
-    conversion: 1 electricity -> 15_cop@data heat
+    conversion: 1 electricity -> ex15_cop@data heat
     conversion_at_min: 1 electricity -> 1 heat
     min_conversion: 0.2
     unit_commitment: binary
@@ -52,7 +52,7 @@ components:
     carrier: heat
     mode: fixed
     node_from: heat_grid
-    value: 15_heatdemand@data
+    value: ex15_heatdemand@data
 
   # We allow "throwing away heat" (essentially allowing the heat_demand to extend beyond the set value)
   heat_demand_deviation:

--- a/src/assets/examples/15_varying_efficiency.iesopt.yaml
+++ b/src/assets/examples/15_varying_efficiency.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     snapshots:

--- a/src/assets/examples/16_noncore_components.iesopt.yaml
+++ b/src/assets/examples/16_noncore_components.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/17_varying_connection_capacity.iesopt.yaml
+++ b/src/assets/examples/17_varying_connection_capacity.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     snapshots:

--- a/src/assets/examples/17_varying_connection_capacity.iesopt.yaml
+++ b/src/assets/examples/17_varying_connection_capacity.iesopt.yaml
@@ -35,7 +35,7 @@ components:
 
   conn:
     type: Connection
-    capacity: 17_capacity@data
+    capacity: ex17_capacity@data
     node_from: node1
     node_to: node2
   

--- a/src/assets/examples/18_addons.iesopt.yaml
+++ b/src/assets/examples/18_addons.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/20_chp.iesopt.yaml
+++ b/src/assets/examples/20_chp.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     snapshots:

--- a/src/assets/examples/22_snapshot_weights.iesopt.yaml
+++ b/src/assets/examples/22_snapshot_weights.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/23_snapshots_from_csv.iesopt.yaml
+++ b/src/assets/examples/23_snapshots_from_csv.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     snapshots:

--- a/src/assets/examples/25_global_parameters.iesopt.yaml
+++ b/src/assets/examples/25_global_parameters.iesopt.yaml
@@ -10,7 +10,7 @@ parameters: files/25/global.iesopt.param.yaml
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/26_initial_states.iesopt.yaml
+++ b/src/assets/examples/26_initial_states.iesopt.yaml
@@ -6,7 +6,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/27_piecewise_linear_costs.iesopt.yaml
+++ b/src/assets/examples/27_piecewise_linear_costs.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/29_advanced_unit_commitment.iesopt.yaml
+++ b/src/assets/examples/29_advanced_unit_commitment.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     solver:

--- a/src/assets/examples/30_representative_snapshots.iesopt.yaml
+++ b/src/assets/examples/30_representative_snapshots.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/31_exclusive_operation.iesopt.yaml
+++ b/src/assets/examples/31_exclusive_operation.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/32_sos.iesopt.yaml
+++ b/src/assets/examples/32_sos.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     solver:

--- a/src/assets/examples/33_benders_investment.iesopt.yaml
+++ b/src/assets/examples/33_benders_investment.iesopt.yaml
@@ -4,7 +4,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     solver:

--- a/src/assets/examples/34_piecewise_linear_costs.iesopt.yaml
+++ b/src/assets/examples/34_piecewise_linear_costs.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     solver:

--- a/src/assets/examples/35_fixed_costs.iesopt.yaml
+++ b/src/assets/examples/35_fixed_costs.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     solver:

--- a/src/assets/examples/36_stochastic_investment.iesopt.yaml
+++ b/src/assets/examples/36_stochastic_investment.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: MILP
     solver:

--- a/src/assets/examples/37_certificates.iesopt.yaml
+++ b/src/assets/examples/37_certificates.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/37_certificates.iesopt.yaml
+++ b/src/assets/examples/37_certificates.iesopt.yaml
@@ -57,7 +57,7 @@ components:
     outputs: {electricity: node2}
     conversion: 1 wind -> 1 electricity
     capacity: 20 out:electricity
-    availability_factor: 07_plant_wind_availability_factor@data
+    availability_factor: ex07_plant_wind_availability_factor@data
 
   gas_certificates:
     type: Node
@@ -98,13 +98,13 @@ components:
     type: Profile
     carrier: electricity
     node_from: node1
-    value: 07_demand1_value@data
+    value: ex07_demand1_value@data
   
   demand2:
     type: Profile
     carrier: electricity
     node_from: node2
-    value: 07_demand2_value@data
+    value: ex07_demand2_value@data
 
   gas_grid:
     type: Node

--- a/src/assets/examples/41_multiobjective_epsilon.iesopt.yaml
+++ b/src/assets/examples/41_multiobjective_epsilon.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP+MO
     snapshots:

--- a/src/assets/examples/42_multiobjective_lexicographic.iesopt.yaml
+++ b/src/assets/examples/42_multiobjective_lexicographic.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP+MO
     snapshots:

--- a/src/assets/examples/43_multiobjective_hierarchical.iesopt.yaml
+++ b/src/assets/examples/43_multiobjective_hierarchical.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP+MO
     snapshots:

--- a/src/assets/examples/44_lossy_connections.iesopt.yaml
+++ b/src/assets/examples/44_lossy_connections.iesopt.yaml
@@ -6,7 +6,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     solver:

--- a/src/assets/examples/45_result_extraction.iesopt.yaml
+++ b/src/assets/examples/45_result_extraction.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
     name:
       model: ExampleModel45
       scenario: SomeScenario_$TIME$

--- a/src/assets/examples/46_constants_in_objective.iesopt.yaml
+++ b/src/assets/examples/46_constants_in_objective.iesopt.yaml
@@ -70,7 +70,7 @@ components:
     outputs: {electricity: elec}
     conversion: ~ -> 1 electricity
     capacity: 1 out:electricity
-    availability_factor: 08_pv@data
+    availability_factor: ex08_pv@data
     objectives: {total_cost: <opex_fom>}
   
   electrolysis:
@@ -84,6 +84,6 @@ components:
     type: Profile
     carrier: h2
     node_from: h2_south
-    value: 08_demand@data
+    value: ex08_demand@data
 
   

--- a/src/assets/examples/46_constants_in_objective.iesopt.yaml
+++ b/src/assets/examples/46_constants_in_objective.iesopt.yaml
@@ -4,7 +4,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/47_disable_components.iesopt.yaml
+++ b/src/assets/examples/47_disable_components.iesopt.yaml
@@ -7,7 +7,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.0.2
+      core: 2.0.3
   optimization:
     problem_type: LP
     snapshots:

--- a/src/assets/examples/48_custom_results.iesopt.yaml
+++ b/src/assets/examples/48_custom_results.iesopt.yaml
@@ -48,7 +48,7 @@ components:
     conversion: ~ -> 1 electricity
     capacity: 10 out:electricity
     marginal_cost: 10 per out:electricity
-    availability_factor: 07_plant_wind_availability_factor@data
+    availability_factor: ex07_plant_wind_availability_factor@data
   
   storage:
     type: CustomStorage

--- a/src/assets/examples/48_custom_results.iesopt.yaml
+++ b/src/assets/examples/48_custom_results.iesopt.yaml
@@ -7,7 +7,7 @@ config:
       model: CustomResults
       scenario: SomeScenario_$TIME$
     version:
-      core: 2.0.2
+      core: 2.0.3
   # ------------------------------------------------------------------------------------------------------------------ #
   optimization:
     problem_type: LP

--- a/src/assets/examples/files/09/profiles.csv
+++ b/src/assets/examples/files/09/profiles.csv
@@ -1,5 +1,5 @@
 name,type,mode,carrier,node_to,node_from,value,cost
 availability,Profile,create,wind,wind,,,
-demand1,Profile,,electricity,,node1,07_demand1_value@data,
-demand2,Profile,,electricity,,node2,07_demand2_value@data,
+demand1,Profile,,electricity,,node1,ex07_demand1_value@data,
+demand2,Profile,,electricity,,node2,ex07_demand2_value@data,
 create_gas,Profile,create,gas,gas_grid,,,50

--- a/src/assets/examples/files/09/units.csv
+++ b/src/assets/examples/files/09/units.csv
@@ -1,3 +1,3 @@
 name,type,inputs,outputs,conversion,capacity,availability_factor
-plant_wind,Unit,"{'wind': 'wind'}","{'electricity': 'node2'}",1 wind -> 1 electricity,10 out:electricity,07_plant_wind_availability_factor@data
+plant_wind,Unit,"{'wind': 'wind'}","{'electricity': 'node2'}",1 wind -> 1 electricity,10 out:electricity,ex07_plant_wind_availability_factor@data
 plant_gas,Unit,"{'gas': 'gas_grid'}","{'electricity': 'node1', 'co2': 'total_co2'}",1 gas -> 0.4 electricity + 0.2 co2,10 out:electricity

--- a/src/assets/examples/files/example_data.csv
+++ b/src/assets/examples/files/example_data.csv
@@ -1,4 +1,4 @@
-07_plant_wind_availability_factor,07_demand1_value,07_demand2_value,08_pv,08_demand,15_cop,15_cop_minconversion,15_heatdemand,17_capacity
+ex07_plant_wind_availability_factor,ex07_demand1_value,ex07_demand2_value,ex08_pv,ex08_demand,ex15_cop,ex15_cop_minconversion,ex15_heatdemand,ex17_capacity
 0.88,2.06,4.88,0,0,2.12,1.484,45,5
 0.07,4.11,3.32,0,0,2.12,1.484,45,3
 0.87,4.07,1.53,0.02,0,2.12,1.484,46,1

--- a/src/core/expression.jl
+++ b/src/core/expression.jl
@@ -27,10 +27,10 @@ function _string_to_fevalexpr(@nospecialize(str::AbstractString))
                         str command = join(JuliaSyntax.untokenize.((last_token, token), str))
                 end
 
-                seperator = popfirst!(tokens)   # TODO: this is actually just `next_token`
-                next_token = popfirst!(tokens)  # this is the token after the seperator
+                separator = popfirst!(tokens)   # TODO: this is actually just `next_token`
+                next_token = popfirst!(tokens)  # this is the token after the separator
 
-                push!(access_order, join(JuliaSyntax.untokenize.((token, seperator, next_token), str)))
+                push!(access_order, join(JuliaSyntax.untokenize.((token, separator, next_token), str)))
                 write(buf, "__el[$(length(access_order) - starting_access_index + 1)]")
                 last_token = next_token
             else

--- a/test/src/basic.jl
+++ b/test/src/basic.jl
@@ -14,6 +14,9 @@
     model = generate!(joinpath(PATH_TESTFILES, "availability_test_failure.iesopt.yaml"))
     @suppress optimize!(model)      # `@test_logs` fails because: https://github.com/JuliaLang/julia/issues/48456
     @test JuMP.termination_status(model) == JuMP.MOI.INFEASIBLE
+
+    model = generate!(joinpath(PATH_TESTFILES, "issue35.iesopt.yaml"))
+    @test access(get_component(model, "electricity_demand").value) ≈ 7e-6
 end
 
 @testset "Filesystem paths" verbose = true begin

--- a/test/test_files/issue35.iesopt.yaml
+++ b/test/test_files/issue35.iesopt.yaml
@@ -1,0 +1,28 @@
+config:
+  optimization:
+    problem_type: LP
+    snapshots:
+      count: 1
+    solver:
+      name: highs
+
+carriers:
+  electricity: {}
+
+components:
+  electricity_node:
+    type: Node
+    carrier: electricity
+
+  electricity_market:
+    type: Profile
+    carrier: electricity
+    node_to: electricity_node
+    cost: 50
+    mode: ranged
+
+  electricity_demand:
+    type: Profile
+    carrier: electricity
+    node_from: electricity_node
+    value: 1e-6 * 7


### PR DESCRIPTION
Fixes #35 

This attempts to (sustainably) fix the error that occurred due to the regex-based splitting of strings during "to expression" conversion. It now properly tokenizes strings. However, that also revealed that column names like `08_pv@data` are ambigous, since that would be valid Julia syntax for `8 * _pv@data`. If this is detected the model building is aborted (since we don't know what a user actually means).

The MWE from #35 is now included as test case, and a base set of reasonable unit tests has been added.

---

This pull request includes updates to various example configuration files to ensure compatibility with version 2.0.3 of the core library. Additionally, it updates the references to data columns in several examples to reflect new naming conventions.

Data column reference updates:

* Updated `availability_factor` and `value` references in `src/assets/examples/07_csv_filestorage.iesopt.yaml` to use the new naming convention. [[1]](diffhunk://#diff-44fabd606db0aa12909cb86bf177d00b7e8abc0166356de79f3eb04b3dfb0c10L66-R67) [[2]](diffhunk://#diff-44fabd606db0aa12909cb86bf177d00b7e8abc0166356de79f3eb04b3dfb0c10L81-R88)
* Updated `availability_factor` and `value` references in `src/assets/examples/08_basic_investment.iesopt.yaml` to use the new naming convention. [[1]](diffhunk://#diff-0d43c848db4590763a1afa52846a166bcf154621551887b867d379fec58d6ad7L90-R90) [[2]](diffhunk://#diff-0d43c848db4590763a1afa52846a166bcf154621551887b867d379fec58d6ad7L103-R103)
* Updated `availability_factor` and `value` references in `src/assets/examples/10_basic_load_shedding.iesopt.yaml` to use the new naming convention. [[1]](diffhunk://#diff-93cbbc03270d7832270301a35684cb9c84eb119d12c6c404e8d6138f9c4a736dL75-R75) [[2]](diffhunk://#diff-93cbbc03270d7832270301a35684cb9c84eb119d12c6c404e8d6138f9c4a736dL88-R88)
* Updated `conversion` and `value` references in `src/assets/examples/15_varying_efficiency.iesopt.yaml` to use the new naming convention. [[1]](diffhunk://#diff-ba195cab7293e60c10813a44acfeb7449f7236b07bdda4b590caacf635d0756eL28-R28) [[2]](diffhunk://#diff-ba195cab7293e60c10813a44acfeb7449f7236b07bdda4b590caacf635d0756eL55-R55)
* Updated `capacity` reference in `src/assets/examples/17_varying_connection_capacity.iesopt.yaml` to use the new naming convention.