### PR TITLE
feat: base version checks on actual VersionNumber

### DIFF
--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -48,10 +48,10 @@ function _prepare_config!(model::JuMP.Model)
         _prepare_config_results!(model)
         _prepare_config_paths!(model)
 
-        current_version_core = string(pkgversion(@__MODULE__))::String
-        version_core = @config(model, general.version.core)::String
-        if version_core != current_version_core
-            @error "The `version.core` (v$(version_core)) entry in the configuration file is different from the current version of `IESopt.jl` (v$(current_version_core)), which might lead to unexpected behavior or errors"
+        v_curr = VersionNumber(string(pkgversion(@__MODULE__))::String)
+        v_core = VersionNumber(@config(model, general.version.core)::String)
+        if (v_core.major != v_curr.major) || (v_curr < v_core)
+            @error "The required `version.core` (v$(v_core)) in the configuration file is not compatible with the current version of `IESopt.jl` (v$(v_curr)), which might lead to unexpected behavior or errors"
         end
 
         unknown_sections = [

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -20,6 +20,12 @@ function _parse_model!(model::JuMP.Model, filename::String, @nospecialize(global
             @debug "Global parameters loaded" Dict(Symbol(k) => v for (k, v) in internal(model).input.parameters)...
         end
 
+        v_curr = VersionNumber(string(pkgversion(@__MODULE__))::String)
+        v_core = VersionNumber(@config(model, general.version.core)::String)
+        if v_curr != v_core
+            @warn "The configured `version.core` (v$(v_core)) in the configuration file is not identical with the current version of `IESopt.jl` (v$(v_curr)); be aware that even bug fixes might change the results and therefore should be considered BREAKING for your project"
+        end
+
         # Pre-load all registered files.
         merge!(internal(model).input.files, _parse_inputfiles(model, @config(model, files)))
         if !isempty(internal(model).input.files)

--- a/test/src/basic.jl
+++ b/test/src/basic.jl
@@ -16,6 +16,24 @@
     @test JuMP.termination_status(model) == JuMP.MOI.INFEASIBLE
 end
 
+@testset "Versioning" begin
+    v_curr = VersionNumber(string(pkgversion(IESopt))::String)
+    v_good = [v_curr, VersionNumber(v_curr.major)]
+    v_bad = [@v_str("1"), VersionNumber(v_curr.major + 1), VersionNumber(v_curr.major, v_curr.minor, v_curr.patch + 1)]
+
+    err_msg = "Error: The required `version.core`"
+
+    fn = String(Assets.get_path("examples", "01_basic_single_node.iesopt.yaml"))
+
+    for v in v_good
+        @test !occursin(err_msg, @capture_err generate!(fn; config=Dict("general.version.core" => string(v))))
+    end
+
+    for v in v_bad
+        @test occursin(err_msg, @capture_err generate!(fn; config=Dict("general.version.core" => string(v))))
+    end
+end
+
 @testset "Filesystem paths" verbose = true begin
     for fn in (
         "include_components.iesopt.yaml",


### PR DESCRIPTION
This pull request includes changes to improve version compatibility checks and add corresponding tests. The most important changes include updating the version comparison logic in the configuration and parser functions, and adding tests to ensure correct behavior.

Improvements to version compatibility checks:

* [`src/config/config.jl`](diffhunk://#diff-e60e3901dac4542f5e3ade9db24eff711259ba2425b98aea82128a67452c07a4L51-R54): Updated the version comparison logic in the `_prepare_config!` function to use `VersionNumber` and added a more detailed error message when versions are incompatible.
* [`src/parser.jl`](diffhunk://#diff-5f4a0613c856b7762a58c6df717c2918a3f13bde7139d996bec2fe8280f53f69R23-R28): Added version comparison logic in the `_parse_model!` function to warn users if the configured version does not match the current version of the package.

Addition of tests:

* [`test/src/basic.jl`](diffhunk://#diff-bd4248f1658abf099f6c5beca234ab9b4e57074c80ebcd057944ee39fa550c5aR19-R36): Added a new test set "Versioning" to verify that the version compatibility checks are working correctly by testing both compatible and incompatible version scenarios.