### PR TITLE
feat: improvements for Connections (delays / losses)

### DIFF
--- a/src/core/connection/exp_in.jl
+++ b/src/core/connection/exp_in.jl
@@ -5,5 +5,6 @@ The construction of a Connection's in/out expressions is directly done in `_conn
 that constructs the variable `flow`.
 """
 function _connection_exp_in!(connection::Connection)
+    connection.exp.in = collect(JuMP.AffExpr(0.0) for _ in get_T(connection.model))
     return nothing
 end

--- a/src/core/connection/exp_in.jl
+++ b/src/core/connection/exp_in.jl
@@ -1,0 +1,9 @@
+@doc raw"""
+    _connection_exp_in!(connection::Connection)
+
+The construction of a Connection's in/out expressions is directly done in `_connection_var_flow!(...)`, the function
+that constructs the variable `flow`.
+"""
+function _connection_exp_in!(connection::Connection)
+    return nothing
+end

--- a/src/core/connection/exp_out.jl
+++ b/src/core/connection/exp_out.jl
@@ -5,5 +5,6 @@ The construction of a Connection's in/out expressions is directly done in `_conn
 that constructs the variable `flow`.
 """
 function _connection_exp_out!(connection::Connection)
+    connection.exp.out = collect(JuMP.AffExpr(0.0) for _ in get_T(connection.model))
     return nothing
 end

--- a/src/core/connection/exp_out.jl
+++ b/src/core/connection/exp_out.jl
@@ -1,0 +1,9 @@
+@doc raw"""
+    _connection_exp_out!(connection::Connection)
+
+The construction of a Connection's in/out expressions is directly done in `_connection_var_flow!(...)`, the function
+that constructs the variable `flow`.
+"""
+function _connection_exp_out!(connection::Connection)
+    return nothing
+end

--- a/src/core/connection/var_flow.jl
+++ b/src/core/connection/var_flow.jl
@@ -69,9 +69,27 @@ function _connection_var_flow!(connection::Connection)
         ntei = components[connection.node_to].exp.injection::Vector{JuMP.AffExpr}
         loss = _prepare(connection.loss; default=0.0)
 
+        if connection.loss_mode == :to
+            connection.exp.in = collect(JuMP.AffExpr(0.0, cvf[t] => 1.0) for t in get_T(model))
+            connection.exp.out =
+                collect(JuMP.AffExpr(0.0, cvf[t] => (1.0 - access(loss, t, Float64))::Float64) for t in get_T(model))
+        elseif connection.loss_mode == :from
+            connection.exp.in = collect(
+                JuMP.AffExpr(0.0, cvf[t] => 1.0 / (1.0 - access(loss, t, Float64))::Float64) for t in get_T(model)
+            )
+            connection.exp.out = collect(JuMP.AffExpr(0.0, cvf[t] => 1.0) for t in get_T(model))
+        elseif connection.loss_mode == :split
+            connection.exp.in = collect(
+                JuMP.AffExpr(0.0, cvf[t] => 1.0 / sqrt(1.0 - access(loss, t, Float64))::Float64) for t in get_T(model)
+            )
+            connection.exp.out = collect(
+                JuMP.AffExpr(0.0, cvf[t] => sqrt(1.0 - access(loss, t, Float64))::Float64) for t in get_T(model)
+            )
+        end
+
         @inbounds @simd for t in get_T(model)
-            JuMP.add_to_expression!(nfei[t], cvf[t], -1.0)
-            JuMP.add_to_expression!(ntei[t], cvf[t], (1.0 - access(loss, t, Float64))::Float64)
+            JuMP.add_to_expression!(nfei[t], connection.exp.in[t], -1.0)
+            JuMP.add_to_expression!(ntei[t], connection.exp.out[t], 1.0)
         end
     end
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -289,15 +289,15 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             nodal_balance = Symbol(pop!(prop, "nodal_balance", :enforce))
 
             components[name] = Node(;
-                model=model,
-                name=name,
-                carrier=carrier,
-                soft_constraints=soft_constraints,
-                soft_constraints_penalty=soft_constraints_penalty,
-                state_lb=state_lb,
-                state_ub=state_ub,
-                state_cyclic=state_cyclic,
-                nodal_balance=nodal_balance,
+                model,
+                name,
+                carrier,
+                soft_constraints,
+                soft_constraints_penalty,
+                state_lb,
+                state_ub,
+                state_cyclic,
+                nodal_balance,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
         elseif type == "Connection"
@@ -342,17 +342,17 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
 
             # Initialize.
             components[name] = Connection(;
-                model=model,
-                name=name,
-                soft_constraints=soft_constraints,
-                soft_constraints_penalty=soft_constraints_penalty,
-                carrier=carrier,
-                lb=lb,
-                ub=ub,
-                capacity=capacity,
-                cost=cost,
-                loss=loss,
-                loss_mode=loss_mode,
+                model,
+                name,
+                soft_constraints,
+                soft_constraints_penalty,
+                carrier,
+                lb,
+                ub,
+                capacity,
+                cost,
+                loss,
+                loss_mode,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
         elseif type == "Profile"
@@ -371,17 +371,17 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
 
             # Initialize.
             components[name] = Profile(;
-                model=model,
-                name=name,
-                carrier=carrier,
-                soft_constraints=soft_constraints,
-                soft_constraints_penalty=soft_constraints_penalty,
-                value=value,
-                mode=mode,
-                lb=lb,
-                ub=ub,
-                cost=cost,
-                allow_deviation=allow_deviation,
+                model,
+                namee,
+                carrier,
+                soft_constraints,
+                soft_constraints_penalty,
+                value,
+                mode,
+                lb,
+                ub,
+                cost,
+                allow_deviation,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
         elseif type == "Unit"
@@ -430,20 +430,20 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
 
             # Initialize.
             components[name] = Unit(;
-                model=model,
-                name=name,
-                soft_constraints=soft_constraints,
-                soft_constraints_penalty=soft_constraints_penalty,
-                inputs=inputs,
-                outputs=outputs,
-                availability=availability,
-                availability_factor=availability_factor,
-                unit_count=unit_count,
-                capacity=capacity,
-                marginal_cost=marginal_cost,
-                unit_commitment=unit_commitment,
-                capacity_carrier=capacity_carrier,
-                marginal_cost_carrier=marginal_cost_carrier,
+                model,
+                name,
+                soft_constraints,
+                soft_constraints_penalty,
+                inputs,
+                outputs,
+                availability,
+                availability_factor,
+                unit_count,
+                capacity,
+                marginal_cost,
+                unit_commitment,
+                capacity_carrier,
+                marginal_cost_carrier,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
         elseif type == "Decision"
@@ -460,14 +460,14 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
 
             # Initialize.
             components[name] = Decision(;
-                model=model,
-                name=name,
-                soft_constraints=soft_constraints,
-                soft_constraints_penalty=soft_constraints_penalty,
-                mode=mode,
-                lb=lb,
-                ub=ub,
-                cost=cost,
+                model,
+                name,
+                soft_constraints,
+                soft_constraints_penalty,
+                mode,
+                lb,
+                ub,
+                cost,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
             # elseif type == "Expression"

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -336,6 +336,7 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             capacity = _convert_to_expression(model, pop!(prop, "capacity", nothing))
             cost = _convert_to_expression(model, pop!(prop, "cost", nothing))
             loss = _convert_to_expression(model, pop!(prop, "loss", nothing))
+            delay = _convert_to_expression(model, pop!(prop, "delay", nothing))
 
             # Convert to Symbol
             loss_mode = Symbol(pop!(prop, "loss_mode", :to))
@@ -353,6 +354,7 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
                 cost,
                 loss,
                 loss_mode,
+                delay,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
         elseif type == "Profile"

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -337,6 +337,9 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             cost = _convert_to_expression(model, pop!(prop, "cost", nothing))
             loss = _convert_to_expression(model, pop!(prop, "loss", nothing))
 
+            # Convert to Symbol
+            loss_mode = Symbol(pop!(prop, "loss_mode", :to))
+
             # Initialize.
             components[name] = Connection(;
                 model=model,
@@ -349,6 +352,7 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
                 capacity=capacity,
                 cost=cost,
                 loss=loss,
+                loss_mode=loss_mode,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
         elseif type == "Profile"

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -372,7 +372,7 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             # Initialize.
             components[name] = Profile(;
                 model,
-                namee,
+                name,
                 carrier,
                 soft_constraints,
                 soft_constraints_penalty,

--- a/test/src/basic.jl
+++ b/test/src/basic.jl
@@ -16,6 +16,27 @@
     @test JuMP.termination_status(model) == JuMP.MOI.INFEASIBLE
 end
 
+@testset "Connection losses" begin
+    model = generate!(joinpath(PATH_TESTFILES, "connection_loss.iesopt.yaml"))
+    optimize!(model)
+
+    @test JuMP.value(get_component(model, "conn1").exp.in[1]) ≈ 10.0 atol = 0.01
+    @test JuMP.value(get_component(model, "conn1").exp.out[1]) ≈ 10.0 atol = 0.01
+
+    @test JuMP.value(get_component(model, "conn2").exp.in[1]) ≈ 10.0 atol = 0.01
+    @test JuMP.value(get_component(model, "conn2").exp.out[1]) ≈ 9.0 atol = 0.01
+
+    @test JuMP.value(get_component(model, "conn3").exp.in[1]) ≈ 10.0 / 0.9 atol = 0.01
+    @test JuMP.value(get_component(model, "conn3").exp.out[1]) ≈ 10.0 atol = 0.01
+
+    @test JuMP.value(get_component(model, "conn4").exp.in[1]) ≈ 10.0 / sqrt(0.9) atol = 0.01
+    @test JuMP.value(get_component(model, "conn4").exp.out[1]) ≈ 10.0 * sqrt(0.9) atol = 0.01
+
+    @test JuMP.value(get_component(model, "conn1").var.flow[1]) ≈ 10.0 atol = 0.01
+    @test JuMP.value(get_component(model, "conn2").var.flow[1]) ≈ 10.0 atol = 0.01
+    @test JuMP.value(get_component(model, "conn3").var.flow[1]) ≈ 10.0 atol = 0.01
+    @test JuMP.value(get_component(model, "conn4").var.flow[1]) ≈ 10.0 atol = 0.01
+end
 @testset "Versioning" begin
     v_curr = VersionNumber(string(pkgversion(IESopt))::String)
     v_good = [v_curr, VersionNumber(v_curr.major)]

--- a/test/src/basic.jl
+++ b/test/src/basic.jl
@@ -16,7 +16,7 @@
     @test JuMP.termination_status(model) == JuMP.MOI.INFEASIBLE
 end
 
-@testset "Connection losses" begin
+@testset "Connection (loss)" begin
     model = generate!(joinpath(PATH_TESTFILES, "connection_loss.iesopt.yaml"))
     optimize!(model)
 
@@ -37,6 +37,26 @@ end
     @test JuMP.value(get_component(model, "conn3").var.flow[1]) ≈ 10.0 atol = 0.01
     @test JuMP.value(get_component(model, "conn4").var.flow[1]) ≈ 10.0 atol = 0.01
 end
+
+@testset "Connection (delay)" begin
+    model = generate!(joinpath(PATH_TESTFILES, "connection_delay.iesopt.yaml"))
+    IESopt.optimize!(model)
+
+    @test all(JuMP.value.(get_component(model, "conn1").exp.in) .≈ [1.0, 1.0, 1.0, 1.0])
+    @test all(JuMP.value.(get_component(model, "conn1").exp.out) .≈ [1.0, 1.0, 1.0, 1.0])
+
+    @test all(JuMP.value.(get_component(model, "conn2").exp.in) .≈ [1.0, 1.0, 0.0, 0.0])
+    @test all(JuMP.value.(get_component(model, "conn2").exp.out) .≈ [0.0, 0.0, 0.9, 0.9])
+
+    @test maximum(abs.(JuMP.value.(get_component(model, "conn3").exp.in) .- [1.111, 0.168, 1.111, 0.0])) <= 1e-3
+    @test maximum(abs.(JuMP.value.(get_component(model, "conn3").exp.out) .- [0.0, 1.0, 0.151, 0.999])) <= 1e-3
+
+    @test maximum(abs.(JuMP.value.(get_component(model, "conn4").exp.in) .- [0.0, 0.0, 1.054, 1.054])) <= 1e-3
+    @test maximum(abs.(JuMP.value.(get_component(model, "conn4").exp.out) .- [0.0, 0.0, 0.948, 0.948])) <= 1e-3
+
+    @test JuMP.objective_value(model) ≈ 10.4985 atol = 0.01
+end
+
 @testset "Versioning" begin
     v_curr = VersionNumber(string(pkgversion(IESopt))::String)
     v_good = [v_curr, VersionNumber(v_curr.major)]

--- a/test/test_files/connection_delay.iesopt.yaml
+++ b/test/test_files/connection_delay.iesopt.yaml
@@ -1,0 +1,75 @@
+config:
+  general:
+    version:
+      core: 2.1.0
+  optimization:
+    problem_type: LP
+    solver:
+      name: highs
+    snapshots:
+      count: 4
+  results:
+    enabled: true
+    memory_only: true
+
+carriers:
+  electricity: {}
+
+components:
+  node1:
+    type: Node
+    carrier: electricity
+  
+  node2:
+    type: Node
+    carrier: electricity
+
+  supply:
+    type: Profile
+    carrier: electricity
+    mode: create
+    node_to: node1
+    cost: 1.0
+  
+  demand:
+    type: Profile
+    carrier: electricity
+    node_from: node2
+    value: [1, 2, 3, 3.84868]
+
+  conn1:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 1
+    delay: 3
+  
+  conn2:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 1
+    loss: 0.10
+    delay: 2.0
+
+  conn3:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 1
+    loss: 0.10
+    loss_mode: from
+    delay: 1
+
+  conn4:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0.0
+    ub: 1.0
+    loss: 0.10
+    loss_mode: split
+    delay: 3.0/3.0 - 1

--- a/test/test_files/connection_loss.iesopt.yaml
+++ b/test/test_files/connection_loss.iesopt.yaml
@@ -1,0 +1,71 @@
+config:
+  general:
+    version:
+      core: 2.1.0
+  optimization:
+    problem_type: LP
+    solver:
+      name: highs
+    snapshots:
+      count: 1
+  results:
+    enabled: true
+    memory_only: true
+
+carriers:
+  electricity: {}
+
+components:
+  node1:
+    type: Node
+    carrier: electricity
+  
+  node2:
+    type: Node
+    carrier: electricity
+
+  supply:
+    type: Profile
+    carrier: electricity
+    mode: create
+    node_to: node1
+  
+  demand:
+    type: Profile
+    carrier: electricity
+    mode: destroy
+    node_from: node2
+    cost: -1.0
+
+  conn1:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 10
+  
+  conn2:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 10
+    loss: 0.10
+
+  conn3:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 10
+    loss: 0.10
+    loss_mode: from
+
+  conn4:
+    type: Connection
+    node_from: node1
+    node_to: node2
+    lb: 0
+    ub: 10
+    loss: 0.10
+    loss_mode: split


### PR DESCRIPTION
This pull request includes several changes to the `Connection` model in the `src/core/connection.jl` file, introducing new features and improving existing functionality. The most important changes include adding support for more configuration options of the `loss` setting, introducing a delay feature for energy transfer, and updating the parsing and validation logic accordingly.

Enhancements to `Connection` model:

* Added `loss_mode` parameter to configure where the fractional loss occurs (`to`, `from`, or `split`).
* Introduced `delay` parameter to model delays in energy transfer between nodes.
* An explicit "in" / "out" expression exists, that can be used to better analyze results.

Validation and parsing updates:

* Updated `_isvalid` function to validate `loss_mode` and `delay` parameters.
* Modified `_parse_components!` function to include `loss_mode` and `delay` parameters in `Connection` parsing.

Expression construction:

* Added `_connection_exp_in!` and `_connection_exp_out!` functions to handle the new `in` and `out` expressions for `Connection`. [[1]](diffhunk://#diff-92dc03af542d8e1f70966b5dcb5e465a7d879108ed2534e56a79ef4a36325392R1-R10) [[2]](diffhunk://#diff-d773e461d76d0ae516ee3d4d9feaad6a8fa098d0831d69e45d637986ba88e9adR1-R10)
* Updated `_connection_var_flow!` function to account for `loss_mode` and `delay` parameters in flow calculations.

Testing:

* Added new test cases in `test/src/basic.jl` to verify the correct behavior of `Connection` with different `loss_mode` and `delay` configurations.
* Included new test files `connection_delay.iesopt.yaml` and `connection_loss.iesopt.yaml` for testing the new features. [[1]](diffhunk://#diff-6404d00104c08b7ccc67bc15e15108bad76b00ec818819be9707be1ebe3ff466R1-R75) [[2]](diffhunk://#diff-f47bf43e7ea2b0339773bae5848b4c82c0b718f3b29084408f41b71119bf20a1R1-R71)