### PR TITLE
chore: prep v2.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IESopt"
 uuid = "ed3f0a38-8ad9-4cf8-877e-929e8d190fe9"
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/assets/examples/01_basic_single_node.iesopt.yaml
+++ b/assets/examples/01_basic_single_node.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     # This specifies the overall type of optimization problem. If using "LP" like here, no component can utilize
     # formulations that are of a "higher" class (e.g. MILP).

--- a/assets/examples/02_advanced_single_node.iesopt.yaml
+++ b/assets/examples/02_advanced_single_node.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/03_basic_two_nodes.iesopt.yaml
+++ b/assets/examples/03_basic_two_nodes.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/04_soft_constraints.iesopt.yaml
+++ b/assets/examples/04_soft_constraints.iesopt.yaml
@@ -17,7 +17,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/05_basic_two_nodes_1y.iesopt.yaml
+++ b/assets/examples/05_basic_two_nodes_1y.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/06_recursion_h2.iesopt.yaml
+++ b/assets/examples/06_recursion_h2.iesopt.yaml
@@ -6,7 +6,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/07_csv_filestorage.iesopt.yaml
+++ b/assets/examples/07_csv_filestorage.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/08_basic_investment.iesopt.yaml
+++ b/assets/examples/08_basic_investment.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/09_csv_only.iesopt.yaml
+++ b/assets/examples/09_csv_only.iesopt.yaml
@@ -6,7 +6,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/10_basic_load_shedding.iesopt.yaml
+++ b/assets/examples/10_basic_load_shedding.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/11_basic_unit_commitment.iesopt.yaml
+++ b/assets/examples/11_basic_unit_commitment.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/12_incremental_efficiency.iesopt.yaml
+++ b/assets/examples/12_incremental_efficiency.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/15_varying_efficiency.iesopt.yaml
+++ b/assets/examples/15_varying_efficiency.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     snapshots:

--- a/assets/examples/16_noncore_components.iesopt.yaml
+++ b/assets/examples/16_noncore_components.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/17_varying_connection_capacity.iesopt.yaml
+++ b/assets/examples/17_varying_connection_capacity.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     snapshots:

--- a/assets/examples/18_addons.iesopt.yaml
+++ b/assets/examples/18_addons.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/20_chp.iesopt.yaml
+++ b/assets/examples/20_chp.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     snapshots:

--- a/assets/examples/22_snapshot_weights.iesopt.yaml
+++ b/assets/examples/22_snapshot_weights.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/23_snapshots_from_csv.iesopt.yaml
+++ b/assets/examples/23_snapshots_from_csv.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     snapshots:

--- a/assets/examples/25_global_parameters.iesopt.yaml
+++ b/assets/examples/25_global_parameters.iesopt.yaml
@@ -10,7 +10,7 @@ parameters: files/25/global.iesopt.param.yaml
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/26_initial_states.iesopt.yaml
+++ b/assets/examples/26_initial_states.iesopt.yaml
@@ -6,7 +6,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/27_piecewise_linear_costs.iesopt.yaml
+++ b/assets/examples/27_piecewise_linear_costs.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/29_advanced_unit_commitment.iesopt.yaml
+++ b/assets/examples/29_advanced_unit_commitment.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     solver:

--- a/assets/examples/30_representative_snapshots.iesopt.yaml
+++ b/assets/examples/30_representative_snapshots.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/31_exclusive_operation.iesopt.yaml
+++ b/assets/examples/31_exclusive_operation.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/32_sos.iesopt.yaml
+++ b/assets/examples/32_sos.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     solver:

--- a/assets/examples/33_benders_investment.iesopt.yaml
+++ b/assets/examples/33_benders_investment.iesopt.yaml
@@ -4,7 +4,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     solver:

--- a/assets/examples/34_piecewise_linear_costs.iesopt.yaml
+++ b/assets/examples/34_piecewise_linear_costs.iesopt.yaml
@@ -3,7 +3,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     solver:

--- a/assets/examples/35_fixed_costs.iesopt.yaml
+++ b/assets/examples/35_fixed_costs.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     solver:

--- a/assets/examples/36_stochastic_investment.iesopt.yaml
+++ b/assets/examples/36_stochastic_investment.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: MILP
     solver:

--- a/assets/examples/37_certificates.iesopt.yaml
+++ b/assets/examples/37_certificates.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/41_multiobjective_epsilon.iesopt.yaml
+++ b/assets/examples/41_multiobjective_epsilon.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP+MO
     snapshots:

--- a/assets/examples/42_multiobjective_lexicographic.iesopt.yaml
+++ b/assets/examples/42_multiobjective_lexicographic.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP+MO
     snapshots:

--- a/assets/examples/43_multiobjective_hierarchical.iesopt.yaml
+++ b/assets/examples/43_multiobjective_hierarchical.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP+MO
     snapshots:

--- a/assets/examples/44_lossy_connections.iesopt.yaml
+++ b/assets/examples/44_lossy_connections.iesopt.yaml
@@ -6,7 +6,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/assets/examples/45_result_extraction.iesopt.yaml
+++ b/assets/examples/45_result_extraction.iesopt.yaml
@@ -4,7 +4,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
     name:
       model: ExampleModel45
       scenario: SomeScenario_$TIME$

--- a/assets/examples/46_constants_in_objective.iesopt.yaml
+++ b/assets/examples/46_constants_in_objective.iesopt.yaml
@@ -4,7 +4,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/47_disable_components.iesopt.yaml
+++ b/assets/examples/47_disable_components.iesopt.yaml
@@ -7,7 +7,7 @@ parameters:
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     snapshots:

--- a/assets/examples/48_custom_results.iesopt.yaml
+++ b/assets/examples/48_custom_results.iesopt.yaml
@@ -7,7 +7,7 @@ config:
       model: CustomResults
       scenario: SomeScenario_$TIME$
     version:
-      core: 2.1.0
+      core: 2.2.0
   # ------------------------------------------------------------------------------------------------------------------ #
   optimization:
     problem_type: LP

--- a/test/test_files/connection_delay.iesopt.yaml
+++ b/test/test_files/connection_delay.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/test/test_files/connection_loss.iesopt.yaml
+++ b/test/test_files/connection_loss.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
   optimization:
     problem_type: LP
     solver:

--- a/test/test_files/issues/38/config.iesopt.yaml
+++ b/test/test_files/issues/38/config.iesopt.yaml
@@ -1,7 +1,7 @@
 config:
   general:
     version:
-      core: 2.1.0
+      core: 2.2.0
     performance:
       logfile: false
     verbosity:


### PR DESCRIPTION
This pull request updates the core version in multiple configuration files across various examples. The core version is being updated from 2.1.0 to 2.2.0 to ensure consistency and compatibility with the latest features and improvements.

Version updates in example configuration files:

* [`assets/examples/01_basic_single_node.iesopt.yaml`](diffhunk://#diff-d0b6a24212b1d34e2d786c2a078299d84dd0a9e8a806bf37a40cf0fd039806f2L7-R7): Updated core version to 2.2.0
* [`assets/examples/02_advanced_single_node.iesopt.yaml`](diffhunk://#diff-442fb6203164b0b55a7b11478a8c076ca0e2cb577ef303a41f5eeaf478eea27dL7-R7): Updated core version to 2.2.0
* [`assets/examples/03_basic_two_nodes.iesopt.yaml`](diffhunk://#diff-aebf0b502a05e5e920904511420306a29d95483e80791a943bb4cf6ed64e579dL7-R7): Updated core version to 2.2.0
* [`assets/examples/04_soft_constraints.iesopt.yaml`](diffhunk://#diff-c2b3a22d41c1f94298636cf4e4d2a085212d7ce46a406a5a5069631ada46c52eL20-R20): Updated core version to 2.2.0
* [`assets/examples/05_basic_two_nodes_1y.iesopt.yaml`](diffhunk://#diff-a26c8c32813e24d5bb406f1f57f099c63c95e890dfc0b3e692335154177d1384L7-R7): Updated core version to 2.2.0

Similar updates have been made to other example files, ensuring all configurations are aligned with the new core version.