### PR TITLE
fix: tag functions as "public" in sub-modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IESopt"
 uuid = "ed3f0a38-8ad9-4cf8-877e-929e8d190fe9"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/utils/modules/Assets.jl
+++ b/src/utils/modules/Assets.jl
@@ -7,6 +7,8 @@ module Assets
 
 using RelocatableFolders
 
+public get_path
+
 """
     get_path(asset_type::String)
 

--- a/src/utils/modules/Utilities.jl
+++ b/src/utils/modules/Utilities.jl
@@ -10,6 +10,10 @@ import ..IESopt: @critical
 import ArgCheck: @argcheck
 import JuMP
 
+public annuity
+public timespan
+public yearspan
+
 """
     annuity(total::Real; lifetime::Real, rate::Float64, fraction::Float64)
 


### PR DESCRIPTION
This pull request includes several changes to the `src/utils/modules` directory, specifically in the `Assets.jl` and `Utilities.jl` files, to make certain functions publicly accessible.

Changes to `Assets.jl`:

* Added `public get_path` to the module `Assets` to make the `get_path` function accessible outside the module.

Changes to `Utilities.jl`:

* Added `public annuity`, `public timespan`, and `public yearspan` to the module `Utilities` to make the respective functions accessible outside the module.

---

This already includes the version bump.