### PR TITLE
feat: implement haskey for _CoreComponentOptContainerDict

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -243,6 +243,10 @@ _build_priority(priority, ::Any) = @error "Unsupported build priority" priority
         return keys(getfield(ccocd, :dict))
     end
 
+    function Base.haskey(ccocd::_CoreComponentOptContainerDict, k::Symbol)
+        return haskey(getfield(ccocd, :dict), k)
+    end
+
     # function Base.getproperty(ccoc::_CoreComponentOptContainer, field::Symbol)
     #     (field == :var) && (return getfield(ccoc, :variables))
     #     (field == :con) && (return getfield(ccoc, :constraints))


### PR DESCRIPTION
Consider

```julia
julia> using IESopt, JuMP

julia> m = Model(); @variable m x[1:10]
10-element Vector{VariableRef}:
 x[1]
 x[2]
 x[3]
 x[4]
 x[5]
 x[6]
 x[7]
 x[8]
 x[9]
 x[10]

julia> ccocd = IESopt._CoreComponentOptContainerDict(Dict(:x => x))
IESopt._CoreComponentOptContainerDict{Vector{VariableRef}}(Dict{Symbol, Vector{VariableRef}}(:x => [x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10]]))

julia> haskey(ccocd, :x)
ERROR: MethodError: no method matching haskey(::IESopt._CoreComponentOptContainerDict{Vector{VariableRef}}, ::Symbol)
The function `haskey` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  haskey(::Base.TermInfo, ::Symbol)
   @ Base terminfo.jl:221
  haskey(::LibGit2.CachedCredentials, ::Any)
   @ LibGit2 C:\Users\SchwabenederD\.julia\juliaup\julia-1.11.2+0.x64.w64.mingw32\share\julia\stdlib\v1.11\LibGit2\src\types.jl:1315
  haskey(::Pkg.Types.Manifest, ::Any)
   @ Pkg C:\Users\SchwabenederD\.julia\juliaup\julia-1.11.2+0.x64.w64.mingw32\share\julia\stdlib\v1.11\Pkg\src\Types.jl:314
  ...

Stacktrace:
 [1] top-level scope
   @ REPL[17]:1

julia>
```

Though this can be achieved currently with

```julia
julia> :x in keys(ccocd)
true
```

I think having an implementation for `haskey` does not hurt.