### PR TITLE
Support "non-integer" delay for Connections

### DIFF
--- a/assets/examples/50_delayed_connections.iesopt.yaml
+++ b/assets/examples/50_delayed_connections.iesopt.yaml
@@ -27,7 +27,7 @@ components:
     type: Connection
     node_from: upper
     node_to: lower
-    delay: 0.33
+    delay: 1 // 3
   inflow:
     type: Profile
     carrier: water

--- a/assets/examples/50_delayed_connections.iesopt.yaml
+++ b/assets/examples/50_delayed_connections.iesopt.yaml
@@ -1,0 +1,44 @@
+config:
+  general:
+    version:
+      core: 2.4.0
+  optimization:
+    problem_type: LP
+    solver:
+      name: highs
+    snapshots:
+      count: 4
+      weights: 0.25
+  results:
+    enabled: true
+    memory_only: true
+
+carriers:
+  water: {}
+
+components:
+  upper:
+    type: Node
+    carrier: water
+  lower:
+    type: Node
+    carrier: water
+  river:
+    type: Connection
+    node_from: upper
+    node_to: lower
+    delay: 0.33
+  inflow:
+    type: Profile
+    carrier: water
+    node_to: upper
+    mode: create
+  outflow:
+    type: Profile
+    carrier: water
+    node_from: lower
+    value:
+      - 1.0
+      - 2.0
+      - 1.5
+      - 0.5

--- a/src/core/connection.jl
+++ b/src/core/connection.jl
@@ -249,15 +249,6 @@ function _isvalid(connection::Connection)
             @critical "Setting <delay> for Connection currently requires equal Snapshot weights" connection =
                 connection.name
         end
-
-        for t in get_T(connection.model)
-            delay = access(connection.delay, t, Float64)
-            if !isinteger(delay / sw[1])
-                # TODO: This is a temporary solution, implement and remove this.
-                @critical "Setting <delay> for Connection currently requires integer delays (thought in Snapshots)" connection =
-                    connection.name
-            end
-        end
     end
 
     return true

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -237,5 +237,15 @@ end
 end
 
 @testitem "50_delayed_connections" tags = [:examples] setup = [TestExampleModule] begin
-    TestExampleModule.check(; obj=0.0)
+    model = TestExampleModule.check(; obj=0.0)
+
+    river = internal(model).results.components["river"]
+    weight = 0.25
+    delay = 1 // 3
+    d, r = divrem(delay, weight)
+    for i in get_T(model)
+        first_inflow = r / weight * river.exp.in[mod1(i - Int(d) - 1, end)]
+        second_inflow = (1 - r / weight) * river.exp.in[mod1(i - Int(d), end)]
+        @test river.exp.out[i] == first_inflow + second_inflow
+    end
 end

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -235,3 +235,7 @@ end
         ).input.files["data"],
     ) == (8760, 8)
 end
+
+@testitem "50_delayed_connections" tags = [:examples] setup = [TestExampleModule] begin
+    TestExampleModule.check(; obj=0.0)
+end


### PR DESCRIPTION
This adds support for Connection delays that are not a multiple of snapshot weights. 

Initially, I wanted to also support arbitrary, i.e. not necessarily equidistant snapshots. However, it turned out that this very easily results in infeasible models:
Just consider, for example, three snapshots with weights `[2, 1, 1]`, a connection from node A to node B with a delay of two hours, and a demand at node B of `[1, 2, 1]`. There is no feasible solution of a connection injection at node A in the first snapshots that satisfies the demand at node B in the last two snapshots.

So, decided to not (yet or at all?) support different snapshot weights in the presence of connection delays.

cc: @GerhardTotschnig