### PR TITLE
Support passing a list of snapshot weights in the yaml config

### DIFF
--- a/src/core/snapshot.jl
+++ b/src/core/snapshot.jl
@@ -72,6 +72,8 @@ function _parse_snapshots!(model::JuMP.Model)
             weights = _getfromcsv(model, file, column)
         elseif config["weights"] isa Number
             weights = ones(length(internal(model).model.T)) .* config["weights"]
+        elseif config["weights"] isa Vector{<:Number}
+            weights = config["weights"]
         end
     else
         weights = ones(length(internal(model).model.T))


### PR DESCRIPTION
While implementing https://github.com/ait-energy/IESopt.jl/pull/56 I wanted to pass a list of different weights in an example and found out that this is currently only possible via CSV.
If that's intentional, feel free to just close this PR.
Otherwise, with this change a list of weights can also be specified in the yaml config.