### PR TITLE
Allow passing `DataFrame`s that are treated as normal CSV input files

### DIFF
--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -460,6 +460,7 @@ function parse!(
     carriers::Dict=_global_settings.carriers,
     components::Dict=_global_settings.components,
     load_components::Dict=_global_settings.load_components,
+    virtual_files::Dict{String, DataFrames.DataFrame}=Dict{String, DataFrames.DataFrame}(),
 )
     @nospecialize
 
@@ -485,6 +486,12 @@ function parse!(
 
     # Load the model specified by `filename`.
     _parse_model!(model, filename) || (@critical "Error while parsing model" filename)
+
+    # Merge virtual files into the model.
+    if !isempty(virtual_files)
+        merge!(internal(model).input.files, virtual_files)
+        @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
+    end
 
     return true
 end

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -489,8 +489,10 @@ function parse!(
 
     # Merge virtual files into the model.
     if !isempty(virtual_files)
-        merge!(internal(model).input.files, virtual_files)
-        @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
+        with_logger(internal(model).logger) do
+            merge!(internal(model).input.files, virtual_files)
+            @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
+        end
     end
 
     return true

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -180,7 +180,7 @@ function _parse_global_addons(model::JuMP.Model, @nospecialize(addons::Dict{Stri
 end
 
 function _parse_inputfiles(model::JuMP.Model)
-    @debug "Start preloading input input files"
+    @debug "Start preloading input files"
     return Dict{String, Union{DataFrames.DataFrame, Module}}(
         name => _getfile(model, filename) for (name, filename) in @config(model, files) if !startswith(name, "_")
     )


### PR DESCRIPTION
Use like this:

```julia
using IESopt: generate!

model = generate!("config.iesopt.yaml"; virtual_files = Dict("data_foo" => some_df))
```

then access it as usual, for example:

```yaml
foo:
  type: Profile
  value: some_col@data_foo
```

Note that this uses `merge!` in the back, with `virtual_files` taking priority, which allows overwriting whatever was loaded from local files.

---

This pull request includes changes to the `src/IESopt.jl` and `src/parser.jl` files to enhance the handling of virtual files and correct a debug message.

Enhancements to virtual file handling:

* [`src/IESopt.jl`](diffhunk://#diff-d9beff68e8b6c30d5506fac48412e6e6497a30013ef3e794563a0eedbe74d44aR463): Added a new parameter `virtual_files::Dict{String, DataFrames.DataFrame}` to the `parse!` function, initializing it as an empty dictionary.
* [`src/IESopt.jl`](diffhunk://#diff-d9beff68e8b6c30d5506fac48412e6e6497a30013ef3e794563a0eedbe74d44aR490-R497): Added logic to merge `virtual_files` into the model within the `parse!` function, including a debug message to confirm the merge.

Debug message correction:

* [`src/parser.jl`](diffhunk://#diff-5f4a0613c856b7762a58c6df717c2918a3f13bde7139d996bec2fe8280f53f69L183-R183): Corrected a debug message in the `_parse_inputfiles` function by removing a duplicated word.