### PR TITLE
Allow transformations in `fixed` Expressions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IESopt"
 uuid = "ed3f0a38-8ad9-4cf8-877e-929e8d190fe9"
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/core/expression.jl
+++ b/src/core/expression.jl
@@ -256,7 +256,12 @@ guaranteeing that the Expression can not be empty.
 const NonEmptyExpressionValue = Union{JuMP.VariableRef, JuMP.AffExpr, Vector{JuMP.AffExpr}, Float64, Vector{Float64}}
 
 _name(e::Expression) = e.empty || isnothing(e.internal) ? "" : e.internal.name
-_isfixed(e::Expression) = (e.empty || (e.value isa Float64) || (e.value isa Vector{Float64}))::Bool
+_isfixed(e::Expression) = (
+    e.empty ||
+    (e.value isa Float64) ||
+    (e.value isa Vector{Float64}) ||
+    (!any(occursin(':', el) for el in e.internal.elements))
+)::Bool
 _isempty(e::Expression) = e.empty::Bool
 
 @recompile_invalidations begin


### PR DESCRIPTION
This fixes #65, and already contains the version bump.

--- 

This pull request includes changes to the `src/core/expression.jl` file to improve the `_isfixed` function by adding a new condition to check for the presence of a colon in the `internal.elements` of an `Expression` (which identifies accessing a Decision). 

The most important change is:

* Modified the `_isfixed` function in `src/core/expression.jl` to include an additional condition that checks if any element in `e.internal.elements` contains a colon. This ensures that the function correctly identifies fixed expressions.