### PR TITLE
Implement "parametric" Expressions

### DIFF
--- a/assets/examples/51_parametric_expressions.iesopt.yaml
+++ b/assets/examples/51_parametric_expressions.iesopt.yaml
@@ -1,0 +1,92 @@
+config:
+  general:
+    version:
+      core: 2.7.0
+  optimization:
+    problem_type: PARAMETRIC+LP
+    snapshots:
+      count: 168
+    solver:
+      name: highs
+  results:
+    enabled: false
+  files:
+    data: example_data.csv
+
+carriers:
+  electricity: {}
+  gas: {}
+  co2: {}
+
+components:
+  node1:
+    type: Node
+    carrier: electricity
+  
+  node2:
+    type: Node
+    carrier: electricity
+    has_state: true
+    state_lb: $(0)
+    state_ub: $(10)
+
+  conn:
+    type: Connection
+    capacity: $(5)
+    node_from: node1
+    node_to: node2
+  
+  # We could also use: `$(10) out:electricity` to model a parametric capacity.
+  plant_wind:
+    type: Unit
+    outputs: {electricity: node2}
+    conversion: ~ -> 1 electricity
+    capacity: 10 out:electricity
+    availability_factor: $(ex07_plant_wind_availability_factor@data)
+  
+  plant_gas:
+    type: Unit
+    inputs: {gas: gas_grid}
+    outputs: {electricity: node1, co2: total_co2}
+    conversion: 1 gas -> 0.4 electricity + 0.2 co2
+    capacity: build:value out:electricity
+  
+  build:
+    type: Decision
+    lb: $(0)
+    ub: $(10)
+    cost: $(0)
+  
+  demand1:
+    type: Profile
+    carrier: electricity
+    node_from: node1
+    value: $(ex07_demand1_value@data)
+  
+  demand2:
+    type: Profile
+    carrier: electricity
+    node_from: node2
+    value: $(ex07_demand2_value@data)
+
+  gas_grid:
+    type: Node
+    carrier: gas
+  
+  total_co2:
+    type: Node
+    carrier: co2
+
+  create_gas:
+    type: Profile
+    carrier: gas
+    node_to: gas_grid
+    mode: create
+    cost: $(50)
+  
+  co2_emissions:
+    type: Profile
+    carrier: co2
+    node_from: total_co2
+    mode: destroy
+    cost: $(100.)

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -20,12 +20,6 @@ include("docify/docify.jl")
 function _build_model!(model::JuMP.Model)
     @info "[build] Begin creating JuMP formulation from components"
 
-    if @config(model, general.performance.string_names, Bool) != model.set_string_names_on_creation
-        new_val = @config(model, general.performance.string_names, Bool)
-        @debug "Overwriting `string_names_on_creation` to `$(new_val)` based on config"
-        JuMP.set_string_names_on_creation(model, new_val)
-    end
-
     # This specifies the order in which components are built. This ensures that model parts that are used later on, are
     # already initialized (e.g. constructing a constraint may use expressions and variables).
     build_order = [

--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -80,3 +80,4 @@ _has_representative_snapshots(model::JuMP.Model) = false  # TODO
 _is_multiobjective(model::JuMP.Model) = (:mo in @config(model, optimization.problem_type))::Bool
 _is_lp(model::JuMP.Model) = (:lp in @config(model, optimization.problem_type))::Bool
 _is_milp(model::JuMP.Model) = (:milp in @config(model, optimization.problem_type))::Bool
+_is_parametric(model::JuMP.Model) = (:parametric in @config(model, optimization.problem_type))::Bool

--- a/src/core/connection.jl
+++ b/src/core/connection.jl
@@ -201,7 +201,7 @@ function _prepare!(connection::Connection)
 
         if _isempty(connection.capacity)
             # Only calculate capacity if it is not given by the user
-            connection.capacity = _convert_to_expression(model, connection.pf_V * connection.pf_I)
+            connection.capacity = _convert_to_expression(model, connection.pf_V * connection.pf_I, "")
         end
         # todo: convert B1
     end

--- a/src/core/connection/obj_cost.jl
+++ b/src/core/connection/obj_cost.jl
@@ -23,12 +23,12 @@ function _connection_obj_cost!(connection::Connection)
 
     model = connection.model
 
-    connection.obj.cost = JuMP.AffExpr(0.0)
+    connection.obj.cost = _isparametric(profile.cost) ? zero(JuMP.QuadExpr) : zero(JuMP.AffExpr)
     for t in get_T(connection.model)
         JuMP.add_to_expression!(
             connection.obj.cost,
             connection.var.flow[t],
-            _weight(model, t) * access(connection.cost, t, Float64),
+            _weight(model, t) * access(connection.cost, t),
         )
     end
 

--- a/src/core/decision.jl
+++ b/src/core/decision.jl
@@ -20,17 +20,17 @@ component's settings, as well as have associated costs.
     raw"""```{"mandatory": "no", "values": "numeric", "unit": "-", "default": "`0`"}```
     Minimum size of the decision value (considered for each "unit" if count allows multiple "units").
     """
-    lb::_OptionalScalarInput = 0
+    lb::Expression = @_default_expression(0.0)
 
     raw"""```{"mandatory": "no", "values": "numeric", "unit": "-", "default": "``+\\infty``"}```
     Maximum size of the decision value (considered for each "unit" if count allows multiple "units").
     """
-    ub::_OptionalScalarInput = nothing
+    ub::Expression = @_default_expression(nothing)
 
     raw"""```{"mandatory": "no", "values": "numeric", "unit": "monetary (per value)", "default": "`0`"}```
     Cost that the decision value induces, given as ``cost \cdot value``.
     """
-    cost::_OptionalScalarInput = nothing
+    cost::Expression = @_default_expression(nothing)
 
     raw"""```{"mandatory": "no", "values": "numeric", "unit": "-", "default": "-"}```
     If `mode: fixed`, this value is used as the fixed value of the decision. This can be useful if this `Decision` was
@@ -165,6 +165,7 @@ include("decision/con_fixed.jl")
 include("decision/con_sos_value.jl")
 include("decision/con_sos1.jl")
 include("decision/con_sos2.jl")
+include("decision/con_value_bounds.jl")
 include("decision/obj_fixed.jl")
 include("decision/obj_sos.jl")
 include("decision/obj_value.jl")
@@ -183,7 +184,9 @@ function _construct_constraints!(decision::Decision)
     _decision_con_fixed!(decision)
     _decision_con_sos_value!(decision)
     _decision_con_sos1!(decision)
-    return _decision_con_sos2!(decision)
+    _decision_con_sos2!(decision)
+    _decision_con_value_bounds!(decision)
+    return nothing
 end
 
 function _construct_objective!(decision::Decision)

--- a/src/core/decision/con_value_bounds.jl
+++ b/src/core/decision/con_value_bounds.jl
@@ -4,7 +4,7 @@
 to be added
 """
 function _decision_con_value_bounds!(decision::Decision)
-    if !isnothing(decision.lb)
+    if !_isempty(decision.lb)
         decision.con.value_lb = @constraint(
             decision.model,
             decision.var.value >= access(decision.lb),
@@ -12,7 +12,7 @@ function _decision_con_value_bounds!(decision::Decision)
         )
     end
 
-    if !isnothing(decision.ub)
+    if !_isempty(decision.ub)
         decision.con.value_ub = @constraint(
             decision.model,
             decision.var.value <= access(decision.ub),

--- a/src/core/decision/con_value_bounds.jl
+++ b/src/core/decision/con_value_bounds.jl
@@ -1,0 +1,24 @@
+@doc raw"""
+    _decision_con_value_bounds!(decision::Decision)
+
+to be added
+"""
+function _decision_con_value_bounds!(decision::Decision)
+    if !isnothing(decision.lb)
+        decision.con.value_lb = @constraint(
+            decision.model,
+            decision.var.value >= access(decision.lb),
+            base_name = make_base_name(decision, "value_lb")
+        )
+    end
+
+    if !isnothing(decision.ub)
+        decision.con.value_ub = @constraint(
+            decision.model,
+            decision.var.value <= access(decision.ub),
+            base_name = make_base_name(decision, "value_ub")
+        )
+    end
+
+    return nothing
+end

--- a/src/core/decision/obj_fixed.jl
+++ b/src/core/decision/obj_fixed.jl
@@ -11,7 +11,7 @@ function _decision_obj_fixed!(decision::Decision)
 
     model = decision.model
 
-    decision.obj.fixed = JuMP.AffExpr(0.0)
+    decision.obj.fixed = _isparametric(profile.cost) ? zero(JuMP.QuadExpr) : zero(JuMP.AffExpr)
     if decision.mode === :sos1
         for i in eachindex(decision.sos)
             if haskey(decision.sos[i], "fixed_cost")

--- a/src/core/decision/obj_value.jl
+++ b/src/core/decision/obj_value.jl
@@ -13,7 +13,7 @@ function _decision_obj_value!(decision::Decision)
     end
 
     model = decision.model
-    decision.obj.value = decision.var.value * decision.cost
+    decision.obj.value = decision.var.value * access(decision.cost)
     push!(internal(model).model.objectives["total_cost"].terms, decision.obj.value)
 
     return nothing

--- a/src/core/decision/var_value.jl
+++ b/src/core/decision/var_value.jl
@@ -17,17 +17,6 @@ function _decision_var_value!(decision::Decision)
 
     if decision.mode === :fixed
         JuMP.fix(decision.var.value, decision.fixed_value)
-    else
-        if !isnothing(decision.ub) && (decision.lb == decision.ub)
-            JuMP.fix(decision.var.value, decision.lb)
-        else
-            if !isnothing(decision.lb)
-                JuMP.set_lower_bound(decision.var.value, decision.lb)
-            end
-            if !isnothing(decision.ub)
-                JuMP.set_upper_bound(decision.var.value, decision.ub)
-            end
-        end
     end
 
     return nothing

--- a/src/core/expression.jl
+++ b/src/core/expression.jl
@@ -274,9 +274,14 @@ _isfixed(e::Expression) = (
 _isempty(e::Expression) = e.empty::Bool
 _isparametric(e::Expression) = e.parametric::Bool
 
-function set_unknown!(e::Expression, value::Real)
+"""
+    modify!(e::Expression, value::Real)
+
+Set the value of a parametric `Expression` object to a scalar value `value`.
+"""
+function modify!(e::Expression, value::Real)
     if !e.parametric
-        @critical "Only parametric expressions support `set_unknown`"
+        @critical "Only parametric expressions support `modify`"
     end
 
     if e.temporal
@@ -288,17 +293,39 @@ function set_unknown!(e::Expression, value::Real)
     return nothing
 end
 
-function set_unknown!(e::Expression, value::Vector{<:Real})
+"""
+    modify!(e::Expression, value::Vector{<:Real})
+
+Set the value of a parametric `Expression` object to a vector value `value`.
+"""
+function modify!(e::Expression, value::Vector{<:Real})
     if !e.parametric
-        @critical "Only parametric expressions support `set_unknown`"
+        @critical "Only parametric expressions support `modify`"
     end
 
     if !e.temporal
-        @critical "Only temporal expressions support `set_unknown` with a vector-valued argument, use `\$(t)` instead of `\$()`"
+        @critical "Only temporal expressions support `modify` with a vector-valued argument, use `\$(t)` instead of `\$()`"
     end
 
     JuMP.set_parameter_value.(e.value, convert.(Float64, value))
     return nothing
+end
+
+"""
+    query(e::Expression)
+
+Query the value of a parametric `Expression` object.
+"""
+function query(e::Expression)
+    if !e.parametric
+        @critical "Only parametric expressions support `query`"
+    end
+
+    if e.temporal
+        return JuMP.parameter_value.(e.value)
+    else
+        return JuMP.parameter_value(e.value)
+    end
 end
 
 @recompile_invalidations begin

--- a/src/core/expression.jl
+++ b/src/core/expression.jl
@@ -266,7 +266,7 @@ _isfixed(e::Expression) = (
 _isempty(e::Expression) = e.empty::Bool
 _isparametric(e::Expression) = e.parametric::Bool
 
-function set_unknown(e::Expression, value::Real)
+function set_unknown!(e::Expression, value::Real)
     if !e.parametric
         @critical "Only parametric expressions support `set_unknown`"
     end
@@ -280,7 +280,7 @@ function set_unknown(e::Expression, value::Real)
     return nothing
 end
 
-function set_unknown(e::Expression, value::Vector{<: Real})
+function set_unknown!(e::Expression, value::Vector{<: Real})
     if !e.parametric
         @critical "Only parametric expressions support `set_unknown`"
     end

--- a/src/core/profile.jl
+++ b/src/core/profile.jl
@@ -145,8 +145,8 @@ function _isvalid(profile::Profile)
     end
 
     if (profile.mode === :create) || (profile.mode === :destroy)
-        !_isempty(profile.lb) && (@warn "Setting <lb> is ignored" profile = profile.name mode = profile.mode)
-        !_isempty(profile.ub) && (@warn "Setting <ub> is ignored" profile = profile.name mode = profile.mode)
+        !_isempty(profile.lb) && (@error "Setting <lb> is ignored" profile = profile.name mode = profile.mode)
+        !_isempty(profile.ub) && (@error "Setting <ub> is ignored" profile = profile.name mode = profile.mode)
     end
 
     if !(profile.mode in [:fixed, :create, :destroy, :ranged])

--- a/src/core/profile.jl
+++ b/src/core/profile.jl
@@ -230,13 +230,13 @@ function _after_construct_variables!(profile::Profile)
         for t in get_T(model)
             _repr_t =
                 internal(model).model.snapshots[t].is_representative ? t :
-                internal(model).model.snapshots[t].representative
-            val = access(profile.value, _repr_t, Float64)
+                internal(model).model.snapshots[t].representative           
 
-            if (profile.mode === :fixed) && false  # TODO _iesopt_config(model).parametric
-                JuMP.fix(profile.var.aux_value[t], val; force=true)
-                JuMP.add_to_expression!(profile.exp.value[t], profile.var.aux_value[t])
+            if _isparametric(profile.value)
+                val = access(profile.value, _repr_t)::JuMP.VariableRef
+                JuMP.add_to_expression!(profile.exp.value[t], val)
             else
+                val = access(profile.value, _repr_t)::Float64
                 JuMP.add_to_expression!(profile.exp.value[t], val)
             end
         end

--- a/src/core/profile.jl
+++ b/src/core/profile.jl
@@ -230,7 +230,7 @@ function _after_construct_variables!(profile::Profile)
         for t in get_T(model)
             _repr_t =
                 internal(model).model.snapshots[t].is_representative ? t :
-                internal(model).model.snapshots[t].representative           
+                internal(model).model.snapshots[t].representative
 
             if _isparametric(profile.value)
                 val = access(profile.value, _repr_t)::JuMP.VariableRef

--- a/src/core/profile/obj_cost.jl
+++ b/src/core/profile/obj_cost.jl
@@ -24,13 +24,9 @@ function _profile_obj_cost!(profile::Profile)
 
     # todo: this is inefficient: we are building up an AffExpr to add it to the objective; instead: add each term
     # todo: furthermore, this always calls VariableRef * Float, which is inefficient, and could be done in add_to_expression
-    profile.obj.cost = JuMP.AffExpr(0.0)
+    profile.obj.cost = _isparametric(profile.cost) ? zero(JuMP.QuadExpr) : zero(JuMP.AffExpr)
     for t in get_T(model)
-        JuMP.add_to_expression!(
-            profile.obj.cost,
-            profile.exp.value[t],
-            _weight(model, t) * access(profile.cost, t, Float64),
-        )
+        JuMP.add_to_expression!(profile.obj.cost, profile.exp.value[t], _weight(model, t) * access(profile.cost, t))
     end
 
     push!(internal(model).model.objectives["total_cost"].terms, profile.obj.cost)

--- a/src/core/profile/var_aux_value.jl
+++ b/src/core/profile/var_aux_value.jl
@@ -27,6 +27,8 @@ function _profile_var_aux_value!(profile::Profile)
 
     if profile.mode === :fixed
         # This Profile's value is already added to the value expression. Nothing to do here.
+    elseif _isparametric(profile.value)
+        # The variable is the Parameter, nothing to do here.
     else
         # Create the variable.
         if !_has_representative_snapshots(model)

--- a/src/core/unit.jl
+++ b/src/core/unit.jl
@@ -550,7 +550,7 @@ function _unit_capacity_limits(unit::Unit)
 
         if _isparametric(unit.availability) || _isparametric(unit.capacity)
             @critical "Parametric <availability> and <capacity> are currently not supported" unit = unit.name
-        end 
+        end
 
         max_conversion =
             min.(

--- a/src/core/unit.jl
+++ b/src/core/unit.jl
@@ -533,11 +533,25 @@ function _unit_capacity_limits(unit::Unit)
 
     # Get correct maximum.
     if !_isempty(unit.availability_factor)
-        max_conversion = min.(1.0, access(unit.availability_factor, NonEmptyNumericalExpressionValue))
+        max_conversion = access(unit.availability_factor)
+        if !_isparametric(unit.availability_factor)
+            if any((>).(max_conversion, 1.0))
+                @critical "Availability factor can not be greater than 1.0" unit = unit.name
+            end
+        else
+            if _isparametric(unit.capacity)
+                @critical "Parametric <availability_factor> and <capacity> are currently not supported" unit = unit.name
+            end
+        end
     elseif !_isempty(unit.availability)
         if !_isfixed(unit.capacity)
             @critical "Endogenuous <capacity> and <availability> are currently not supported" unit = unit.name
         end
+
+        if _isparametric(unit.availability) || _isparametric(unit.capacity)
+            @critical "Parametric <availability> and <capacity> are currently not supported" unit = unit.name
+        end 
+
         max_conversion =
             min.(
                 1.0,

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -26,6 +26,13 @@ function _parse_model!(model::JuMP.Model, filename::String)
             @warn "The configured `version.core` (v$(v_core)) in the configuration file is not identical with the current version of `IESopt.jl` (v$(v_curr)); be aware that even bug fixes might change the results and therefore should be considered BREAKING for your project"
         end
 
+        # Already set `string_names_on_creation`, since we rely on it during component parsing (for parameter names).
+        if @config(model, general.performance.string_names, Bool) != model.set_string_names_on_creation
+            new_val = @config(model, general.performance.string_names, Bool)
+            @debug "Overwriting `string_names_on_creation` to `$(new_val)` based on config"
+            JuMP.set_string_names_on_creation(model, new_val)
+        end
+
         # Pre-load all registered files.
         merge!(internal(model).input.files, _parse_inputfiles(model))
         if !isempty(internal(model).input.files)
@@ -234,6 +241,9 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
 
     has_invalid_component_name = false
 
+    # Dynamic helper function for base names, before we have actual components (=> can't use `make_base_name`).
+    mkbn(n::String, sfx::String) = JuMP.set_string_names_on_creation(model) ? "$(n).par.$(sfx)" : ""
+
     for (desc, prop) in description
         if _parse_bool(model, pop!(prop, "disabled", false)) || !_parse_bool(model, pop!(prop, "enabled", true))
             @critical "[parse] Disabled components should not end up in parse"
@@ -290,8 +300,8 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             carrier = internal(model).model.carriers[pop!(prop, "carrier")]
 
             # Convert to _Expression.
-            state_lb = _convert_to_expression(model, pop!(prop, "state_lb", nothing))
-            state_ub = _convert_to_expression(model, pop!(prop, "state_ub", nothing))
+            state_lb = _convert_to_expression(model, pop!(prop, "state_lb", nothing), mkbn(name, "state_lb"))
+            state_ub = _convert_to_expression(model, pop!(prop, "state_ub", nothing), mkbn(name, "state_ub"))
 
             # Convert to Symbol
             state_cyclic = Symbol(pop!(prop, "state_cyclic", :eq))
@@ -340,12 +350,12 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             end
 
             # Convert to _Expression.
-            lb = _convert_to_expression(model, pop!(prop, "lb", nothing))
-            ub = _convert_to_expression(model, pop!(prop, "ub", nothing))
-            capacity = _convert_to_expression(model, pop!(prop, "capacity", nothing))
-            cost = _convert_to_expression(model, pop!(prop, "cost", nothing))
-            loss = _convert_to_expression(model, pop!(prop, "loss", nothing))
-            delay = _convert_to_expression(model, pop!(prop, "delay", nothing))
+            lb = _convert_to_expression(model, pop!(prop, "lb", nothing), mkbn(name, "lb"))
+            ub = _convert_to_expression(model, pop!(prop, "ub", nothing), mkbn(name, "ub"))
+            capacity = _convert_to_expression(model, pop!(prop, "capacity", nothing), mkbn(name, "capacity"))
+            cost = _convert_to_expression(model, pop!(prop, "cost", nothing), mkbn(name, "cost"))
+            loss = _convert_to_expression(model, pop!(prop, "loss", nothing), mkbn(name, "loss"))
+            delay = _convert_to_expression(model, pop!(prop, "delay", nothing), mkbn(name, "delay"))
 
             # Convert to Symbol
             loss_mode = Symbol(pop!(prop, "loss_mode", :to))
@@ -371,10 +381,10 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             carrier = internal(model).model.carriers[pop!(prop, "carrier")]
 
             # Convert to _Expression.
-            value = _convert_to_expression(model, pop!(prop, "value", nothing))
-            lb = _convert_to_expression(model, pop!(prop, "lb", nothing))
-            ub = _convert_to_expression(model, pop!(prop, "ub", nothing))
-            cost = _convert_to_expression(model, pop!(prop, "cost", nothing))
+            value = _convert_to_expression(model, pop!(prop, "value", nothing), mkbn(name, "value"))
+            lb = _convert_to_expression(model, pop!(prop, "lb", nothing), mkbn(name, "lb"))
+            ub = _convert_to_expression(model, pop!(prop, "ub", nothing), mkbn(name, "ub"))
+            cost = _convert_to_expression(model, pop!(prop, "cost", nothing), mkbn(name, "cost"))
 
             # Convert to Symbol
             mode = Symbol(pop!(prop, "mode", :fixed))
@@ -425,11 +435,16 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             end
 
             # Convert to _Expression.
-            availability = _convert_to_expression(model, pop!(prop, "availability", nothing))
-            availability_factor = _convert_to_expression(model, pop!(prop, "availability_factor", nothing))
-            unit_count = _convert_to_expression(model, pop!(prop, "unit_count", 1))
-            capacity = _convert_to_expression(model, _capacity)
-            marginal_cost = _convert_to_expression(model, _marginal_cost)
+            availability =
+                _convert_to_expression(model, pop!(prop, "availability", nothing), mkbn(name, "availability"))
+            availability_factor = _convert_to_expression(
+                model,
+                pop!(prop, "availability_factor", nothing),
+                mkbn(name, "availability_factor"),
+            )
+            unit_count = _convert_to_expression(model, pop!(prop, "unit_count", 1), mkbn(name, "unit_count"))
+            capacity = _convert_to_expression(model, _capacity, mkbn(name, "capacity"))
+            marginal_cost = _convert_to_expression(model, _marginal_cost, mkbn(name, "marginal_cost"))
 
             # Convert to Symbol
             unit_commitment = Symbol(pop!(prop, "unit_commitment", :off))
@@ -461,9 +476,9 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             # Convert to Symbol
             mode = Symbol(pop!(prop, "mode", :linear))
 
-            lb = _convert_to_expression(model, pop!(prop, "lb", 0))
-            ub = _convert_to_expression(model, pop!(prop, "ub", nothing))
-            cost = _convert_to_expression(model, pop!(prop, "cost", nothing))
+            lb = _convert_to_expression(model, pop!(prop, "lb", 0), mkbn(name, "lb"))
+            ub = _convert_to_expression(model, pop!(prop, "ub", nothing), mkbn(name, "ub"))
+            cost = _convert_to_expression(model, pop!(prop, "cost", nothing), mkbn(name, "cost"))
 
             # Initialize.
             components[name] = Decision(;

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -8,7 +8,7 @@ end
     expressions = _CoreComponentOptContainerDict{Union{JuMP.AffExpr, Vector{JuMP.AffExpr}}}()
     variables = _CoreComponentOptContainerDict{Union{JuMP.VariableRef, Vector{JuMP.VariableRef}}}()
     constraints = _CoreComponentOptContainerDict{Union{JuMP.ConstraintRef, Vector{<:JuMP.ConstraintRef}}}()       # TODO: this clashes with a more specific definition of `ConstraintRef` in JuMP
-    objectives = _CoreComponentOptContainerDict{JuMP.AffExpr}()
+    objectives = _CoreComponentOptContainerDict{Union{JuMP.AffExpr, JuMP.QuadExpr}}()
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ include("src/examples.jl")
         end
 
         @testset "JET.jl" begin
-            # JET.test_package(IESopt; target_modules=(IESopt,))
+            JET.test_package(IESopt; target_modules=(IESopt,))
         end
     end
 

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -250,7 +250,7 @@ end
     end
 end
 
-@testitem "51_parametric_expressions" tags = [:examples] setup = [TestExampleModule] begin
+@testitem "51_parametric_expressions" tags = [:examples] setup = [Dependencies, TestExampleModule] begin
     fn_non_parametric = String(Assets.get_path("examples", "07_csv_filestorage.iesopt.yaml"))
     fn_parametric = String(Assets.get_path("examples", "51_parametric_expressions.iesopt.yaml"))
 


### PR DESCRIPTION
This is a pretty complete (but rather basic) implementation of parametric `Expression`s. It currently uses the `JuMP.ParameterRef` approach. Tests are passing, a new example has been added. I probably missed something somewhere, but it should not break too many non-parametric things.

_I would consider this highly experimental for now, so I'd like to "just get that in" and see if we can get some actual application feedback from the MGA topic or from some rolling window optimization (or MPC) to improve on it. Felt like there will be some learnings that we probably can't easily "think through" without just playing around with it._

---

@daschw What are your thoughts on the naming for the public functions `modify!(expression, new_value)` and `query(expression)`?

> I do not really want to use "parameter" anywhere (since we already have model parameters, etc., and I fear that people will start mixing them up). My first thought was calling these "unknowns", with `set_unknown!(expression, new_value)` and `get_unknown(expression)`, but I thought "modify" is more expressive. Wasn't super happy with "query" then, but did not want to go for "access" or "get" (because we are already using those for other stuff) and "query" was the only reasonable expressive thing I came up with...

## Motivation

This is based on example 07, with 8760 snapshots. Comparing "generate and solve each time" versus "pre-generate once" with "modify and re-solve each time".

Non-parametric:
```console
Benchmark: 3 samples with 5 evaluations
        824.651 ms (13720309.20 allocs: 598.877 MiB, 36.25% gc time)
        841.027 ms (13720331.60 allocs: 598.878 MiB, 37.79% gc time)
        892.024 ms (13720400.40 allocs: 598.882 MiB, 42.72% gc time)
```

Parametric:
```console
Benchmark: 4 samples with 5 evaluations
        514.215 ms (12063866 allocs: 386.921 MiB, 7.79% gc time)
        571.527 ms (12063866 allocs: 386.921 MiB, 16.12% gc time)
        575.096 ms (12063866 allocs: 386.921 MiB, 16.26% gc time)
        579.452 ms (12063866 allocs: 386.921 MiB, 16.84% gc time)
```

> Approximately 120 ms are spent in HiGHS solving the model.  
> Therefore, roughly 730 ms versus 440 ms for the IESopt part, **resulting in a 40% speedup**.  
> Note: Around 150 ms are spent in result extraction, so disabling this ups that to a 50% speedup (580 ms vs. 290 ms).

## Rough idea

Doing this

```yaml
config:
  optimization:
    problem_type: PARAMETRIC+LP
```

allows us to prepare a proper objective function (`QuadExpr`) assuming that some `Parameter`s might be added to it.

The following then allows to parameterize some scalar settings, while providing default values:

```yaml
my_decision:
  type: Decision
  lb: $(0)
  ub: $(10)
  cost: $(0)
```

One can use `cost: $()` to "not" provide a default (since we still need one internally "no" always means `0`).

Similarly for temporal expression the following works:

```yaml
demand:
  type: Profile
  carrier: electricity
  node_from: node
  value: $(col@file)
```

Again, `value: $(t)` acts as the "no" default syntax for a temporal expression.

## (Re-)optimizing

The approach then looks like this:

```julia
using IESopt

# Construct and solve the default config.
model = generate!("config.iesopt.yaml")
optimize!(model)

# Change the cost of the Decision and re-solve.
modify!(get_component(model, "my_decision").cost, 100)
optimize!(model)

# Extract the (current) value of the demand.
ts = query(get_component(model, "demand").value)

# Set the demand to "static 15" (a temporal parametric expression does not need
# a vector-valued setter value), and re-solve.
modify!(get_component(model, "demand").value, 15.0)
optimize!(model)

# Set the demand to the initial profile time series, scaled with "+ 25%", and re-solve.
modify!(get_component(model, "demand").value, 1.25 .* ts)
optimize!(model)
```

The "nice" thing behind that is, that we can directly work with the actual `Expression` objects, which can be accessed from Python in exactly the same way. No need to "register" parameters in the model, look them up in any way, etc.

---

The model also prints pretty nicely now (shortened the output to show some lines as example):

```console
Min 100 co2_emissions.aux_value[1] + 50 create_gas.aux_value[1]
Subject to
 node1.nodalbalance : -demand1.par.value[1] + plant_gas.conversion[1] - conn.flow[1] = 0
 ...
 build.value_lb : -build.par.lb + build.value ≥ 0
 ...
 conn.flow_lb[1] : conn.par.capacity + conn.flow[1] ≥ 0
 ...
 plant_wind.conversion_ub[1] : -10 plant_wind.par.availability_factor[1] + plant_wind.conversion[1] ≤ 0
 ...
 demand2.par.value[1] ∈ MathOptInterface.Parameter{Float64}(4.88)
 ...
 plant_wind.par.availability_factor[1] ∈ MathOptInterface.Parameter{Float64}(0.88)
 conn.par.capacity ∈ MathOptInterface.Parameter{Float64}(5.0)
```

Note that the `.par.` is just cosmetic, to be in line with the other things. There is no actual `build.par.lb` entry in the "opt container dict", because it's just `some_component.lb` (the actual field) that already contains this. For stuff like Profiles that might be mistaken for the actual "value" (the variable) in the print, which is called `foo.var.value`. I felt that `foo.par.value` is better than just `foo.value`.

## What's missing?

Updates to the documentation and the Python wrapper to expose the functions.

## Quick notes on issues to keep in mind

- `set = JuMP.Parameter(0)` is not properly supported by `HiGHS` (and others?) if using a direct model. Using fixed variables should in theory still be possible, so we should investigate further.
- It may be, that there is a more efficient way than using an optimize hook to "fix" the quadratic objective function pre-solver (the main issue is that `HiGHS` does not detect that it's actually an LP, but maybe we can report that?).
- There's an old bridge-based proof of concept hidden somewhere in a `JuMP` (or `MOI`?) PR from roughly two years ago; that could help with the currently still existing problem of quadratic constraints (which occur for various `Unit` related configurations).
- The implementation is pretty general for any `Expression`, but I've only tested it with the "common" configurations and only partially for `Unit`s. It can be expected that unit commitment or similar more complex formulations may be bricked by that (note: I've tested `capacity` and `availability_factor` as the most common ones and they work).
- Conversion expressions are currently not supported at all (but they might need a slightly different approach anyways).
- A fully parametric model might be really easy to "docify" - we should keep track of that opportunity.

---

## Auto-generated summary

This pull request introduces significant changes to support parametric expressions and optimization in the `IESopt` package. The most important changes include the addition of parametric capabilities, modifications to the objective function handling, and updates to various components to support the new features.

### Parametric Capabilities:

* Added support for parametric expressions in the configuration file `assets/examples/51_parametric_expressions.iesopt.yaml`.
* Introduced the `_is_parametric` function to check if a model is parametric.
* Implemented the `_optimize_hook_parametric` function to handle quadratic objectives for parametric models.

### Objective Function Handling:

* Modified the `_build_model!` function to include a hook for parametric models and handle the current objective accordingly.
* Updated the `_optimize!` function to include a TODO for substituting quadratic objectives with affine expressions in parametric models.

### Component Updates:

* Changed the `Decision` component to use expressions for `lb`, `ub`, and `cost` fields.
* Added a new function `_decision_con_value_bounds!` to handle value bounds constraints for decisions.
* Updated the `Profile` component to handle parametric costs and values. [[1]](diffhunk://#diff-644f979c5d1aaf0a0e8be733a3698def1719c8ddfac3bb61ed061251f556a330L27-R29) [[2]](diffhunk://#diff-04652dd92eb0c7da12771555e69d3786366c492b4614597d7378d1ee632530fcL234-R239)

### Expression Handling:

* Added functions to modify and query parametric expressions, and updated the `_convert_to_expression` function to handle parametric cases. [[1]](diffhunk://#diff-3de4f6cf6c2d2992db59fa1ed22a940b2ba67fbae2cbcbed34c819228d1f00d9R275-R329) [[2]](diffhunk://#diff-3de4f6cf6c2d2992db59fa1ed22a940b2ba67fbae2cbcbed34c819228d1f00d9L286-L295)
* Updated the `_prepare` and `access` functions to support parametric expressions. [[1]](diffhunk://#diff-3de4f6cf6c2d2992db59fa1ed22a940b2ba67fbae2cbcbed34c819228d1f00d9L352-R458) [[2]](diffhunk://#diff-3de4f6cf6c2d2992db59fa1ed22a940b2ba67fbae2cbcbed34c819228d1f00d9R481-R482)

### Miscellaneous:

* Removed the `string_names_on_creation` configuration check from the `_build_model!` function.
* Updated various functions to handle parametric expressions and costs, including `_connection_obj_cost!` and `_decision_obj_fixed!`. [[1]](diffhunk://#diff-61105a6d417f16a87f01d2a38bee62e2c7ea78b2802f232800fc7247551b9aa4L26-R31) [[2]](diffhunk://#diff-3dea98a6b334a166e5da282954a2e33741d036f0c40ba7bd21135d55fb5ed5d2L14-R14)