### PR TITLE
Respect snapshot `offset` and `count` when loading virtual files

### DIFF
--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -497,7 +497,7 @@ function parse!(
 
                 # Offset and aggregation don't work together.
                 if !isnothing(aggregation) && offset != 0
-                    @critical "Snapshot aggregation and non-zero offsets are currently not supported"
+                    @critical "[parse] Snapshot aggregation and non-zero offsets are currently not supported"
                 end
 
                 # Get the number of df rows and and the model's snapshot count
@@ -507,11 +507,20 @@ function parse!(
                 # Get the range of df rows we want to return.
                 # Without snapshot aggregation we can return the rows specified by offset and count.
                 # Otherwise, we start at 1 and multiply the number of rows to return by the number of snapshots to aggregate.
+                if offset != 0
+                    try
+                        if !@config(model, optimization.snapshots.apply_to_virtual_files, Bool)
+                            offset = 0
+                        end
+                    catch
+                        @critical "[parse] Missing `optimization.snapshots.apply_to_virtual_files` when using offset"
+                    end
+                end
                 from, to = isnothing(aggregation) ? (offset + 1, offset + count) : (1, count * (aggregation::Float64))
 
                 # Check if the range of rows is in bounds.
                 if from < 1 || to > nrows || from > to
-                    @critical "Trying to access data with out-of-bounds or empty range" filename from to nrows
+                    @critical "[parse] Trying to access data with out-of-bounds or empty range" filename from to nrows
                 end
 
                 internal(model).input.files[fn] = DataFrames.mapcols!(
@@ -520,7 +529,7 @@ function parse!(
                     cols=names(df, Union{Int, Missing}),
                 )::DataFrames.DataFrame
             end
-            @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
+            @debug "[parse] Successfully merged $(length(virtual_files)) virtual file(s)"
         end
     end
 

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -514,8 +514,11 @@ function parse!(
                     @critical "Trying to access data with out-of-bounds or empty range" filename from to nrows
                 end
 
-                internal(model).input.files[fn] =
-                    DataFrames.mapcols!(v -> float.(v), df[from:to, :]; cols=names(df, Int))
+                internal(model).input.files[fn] = DataFrames.mapcols!(
+                    v -> float.(v),
+                    df[from:to, :];
+                    cols=names(df, Union{Int, Missing}),
+                )::DataFrames.DataFrame
             end
             @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
         end

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -490,7 +490,35 @@ function parse!(
     # Merge virtual files into the model.
     if !isempty(virtual_files)
         with_logger(internal(model).logger) do
-            merge!(internal(model).input.files, virtual_files)
+            for (fn, df) in virtual_files
+                # Get some snapshot config parameters.
+                offset = @config(model, optimization.snapshots.offset, Int64)
+                aggregation = @config(model, optimization.snapshots.aggregate)
+
+                # Offset and aggregation don't work together.
+                if !isnothing(aggregation) && offset != 0
+                    @critical "Snapshot aggregation and non-zero offsets are currently not supported"
+                end
+
+                # Get the number of df rows and and the model's snapshot count
+                nrows = size(df, 1)
+                count = @config(model, optimization.snapshots.count, Int64)
+
+                # Get the range of df rows we want to return.
+                # Without snapshot aggregation we can return the rows specified by offset and count.
+                # Otherwise, we start at 1 and multiply the number of rows to return by the number of snapshots to aggregate.
+                from, to = isnothing(aggregation) ? (offset + 1, offset + count) : (1, count * (aggregation::Float64))
+
+                # Check if the range of rows is in bounds.
+                if from < 1 || to > nrows || from > to
+                    @critical "Trying to access data with out-of-bounds or empty range" filename from to nrows
+                end
+
+                internal(model).input.files[fn] = DataFrames.mapcols(
+                    v -> v isa AbstractVector{Int64} ? convert(Vector{Float64}, v) : v,
+                    identity.(df[from:to, :]::DataFrames.DataFrame)::DataFrames.DataFrame,
+                )::DataFrames.DataFrame
+            end
             @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
         end
     end

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -514,10 +514,8 @@ function parse!(
                     @critical "Trying to access data with out-of-bounds or empty range" filename from to nrows
                 end
 
-                internal(model).input.files[fn] = DataFrames.mapcols(
-                    v -> v isa AbstractVector{Int64} ? convert(Vector{Float64}, v) : v,
-                    identity.(df[from:to, :]::DataFrames.DataFrame)::DataFrames.DataFrame,
-                )::DataFrames.DataFrame
+                internal(model).input.files[fn] =
+                    DataFrames.mapcols!(v -> float.(v), df[from:to, :]; cols=names(df, Int))
             end
             @debug "Successfully merged $(length(virtual_files)) virtual file(s)"
         end

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -509,11 +509,11 @@ function parse!(
                 # Otherwise, we start at 1 and multiply the number of rows to return by the number of snapshots to aggregate.
                 if offset != 0
                     try
-                        if !@config(model, optimization.snapshots.apply_to_virtual_files, Bool)
+                        if !@config(model, optimization.snapshots.offset_virtual_files, Bool)
                             offset = 0
                         end
                     catch
-                        @critical "[parse] Missing `optimization.snapshots.apply_to_virtual_files` when using offset"
+                        @critical "[parse] Missing `optimization.snapshots.offset_virtual_files` when using offset"
                     end
                 end
                 from, to = isnothing(aggregation) ? (offset + 1, offset + count) : (1, count * (aggregation::Float64))

--- a/src/config/sections/optimization.jl
+++ b/src/config/sections/optimization.jl
@@ -28,8 +28,8 @@ function _prepare_config_optimization!(model::JuMP.Model)
         "representatives" => get(data_snapshots, "representatives", nothing),
         "aggregate" => get(data_snapshots, "aggregate", nothing),
     )
-    if haskey(data_snapshots, "apply_to_virtual_files")
-        @config(model, optimization.snapshots.apply_to_virtual_files) = data_snapshots["apply_to_virtual_files"]::Bool
+    if haskey(data_snapshots, "offset_virtual_files")
+        @config(model, optimization.snapshots.offset_virtual_files) = data_snapshots["offset_virtual_files"]::Bool
     end
 
     # Objectives.

--- a/src/config/sections/optimization.jl
+++ b/src/config/sections/optimization.jl
@@ -20,7 +20,7 @@ function _prepare_config_optimization!(model::JuMP.Model)
     count = data_snapshots["count"]
     weight_config = get(data_snapshots, "weights", nothing)
     weights = weight_config isa Real ? float(weight_config) : weight_config
-    @config(model, optimization.snapshots) = Dict(
+    @config(model, optimization.snapshots) = Dict{String, Any}(
         "count" => count::Int64,
         "offset" => get(data_snapshots, "offset", 0)::Int64,
         "names" => get(data_snapshots, "names", nothing),
@@ -28,6 +28,9 @@ function _prepare_config_optimization!(model::JuMP.Model)
         "representatives" => get(data_snapshots, "representatives", nothing),
         "aggregate" => get(data_snapshots, "aggregate", nothing),
     )
+    if haskey(data_snapshots, "apply_to_virtual_files")
+        @config(model, optimization.snapshots.apply_to_virtual_files) = data_snapshots["apply_to_virtual_files"]::Bool
+    end
 
     # Objectives.
     objectives = get(data, "objectives", Dict{String, Vector{String}}())

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -350,9 +350,10 @@ function _getcsv(model::JuMP.Model, filename::String; sink=DataFrames.DataFrame,
         @critical "Trying to access data with out-of-bounds or empty range" filename from to nrows
     end
 
-    return DataFrames.mapcols(
-        v -> v isa AbstractVector{Int64} ? convert(Vector{Float64}, v) : v,
-        identity.(table[from:to, :]::DataFrames.DataFrame)::DataFrames.DataFrame,
+    return DataFrames.mapcols!(
+        v -> float.(v),
+        table[from:to, :];
+        cols=names(table, Union{Int, Missing}),
     )::DataFrames.DataFrame
 end
 

--- a/test/src/issues.jl
+++ b/test/src/issues.jl
@@ -43,7 +43,7 @@ end
     config = Dict(
         "optimization.snapshots.count" => 168,
         "optimization.snapshots.offset" => 168,
-        "optimization.snapshots.apply_to_virtual_files" => true,
+        "optimization.snapshots.offset_virtual_files" => true,
     )
     obj = JuMP.objective_value(IESopt.run(cfg; config))
     @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
@@ -53,7 +53,7 @@ end
     config = Dict(
         "optimization.snapshots.count" => 168,
         "optimization.snapshots.offset" => 168,
-        "optimization.snapshots.apply_to_virtual_files" => false,
+        "optimization.snapshots.offset_virtual_files" => false,
     )
     @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
 end

--- a/test/src/issues.jl
+++ b/test/src/issues.jl
@@ -14,3 +14,26 @@ end
     optimize!(model)
     @test JuMP.objective_value(model) ≈ 0.0 atol = 0.1
 end
+
+@testset "#95" begin
+    DataFrames = IESopt.DataFrames
+    CSV = IESopt.CSV
+    JuMP = IESopt.JuMP
+
+    data = normpath(Assets.get_path("examples"), "files", "example_data.csv")
+    cfg = String(Assets.get_path("examples", "07_csv_filestorage.iesopt.yaml"))
+
+    df = CSV.read(data, DataFrames.DataFrame; stringtype=String)
+    df_mod = copy(df)
+    df_mod[!, "ex07_plant_wind_availability_factor"] .= 0
+
+    @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df_mod))) ≈ 7.69679225e6 atol = 0.1
+
+    config = Dict("optimization.snapshots.count" => 168)
+    obj = JuMP.objective_value(IESopt.run(cfg; config))
+    @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
+
+    config = Dict("optimization.snapshots.count" => 168, "optimization.snapshots.offset" => 168)
+    obj = JuMP.objective_value(IESopt.run(cfg; config))
+    @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
+end

--- a/test/src/issues.jl
+++ b/test/src/issues.jl
@@ -34,6 +34,26 @@ end
     @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
 
     config = Dict("optimization.snapshots.count" => 168, "optimization.snapshots.offset" => 168)
+    @test_logs (:error, "[generate] Error(s) during model generation") match_mode = :any generate!(
+        cfg;
+        virtual_files=Dict("data" => df),
+        config,
+    )
+
+    config = Dict(
+        "optimization.snapshots.count" => 168,
+        "optimization.snapshots.offset" => 168,
+        "optimization.snapshots.apply_to_virtual_files" => true,
+    )
     obj = JuMP.objective_value(IESopt.run(cfg; config))
+    @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
+
+    config = Dict("optimization.snapshots.count" => 168, "optimization.snapshots.offset" => 0)
+    obj = JuMP.objective_value(IESopt.run(cfg; config))
+    config = Dict(
+        "optimization.snapshots.count" => 168,
+        "optimization.snapshots.offset" => 168,
+        "optimization.snapshots.apply_to_virtual_files" => false,
+    )
     @test JuMP.objective_value(IESopt.run(cfg; virtual_files=Dict("data" => df), config)) ≈ obj atol = 0.1
 end


### PR DESCRIPTION
Fixes #95 

Edit: also fixes #99 

This is basically copy-pasted from the code loading CSV files:
https://github.com/ait-energy/IESopt.jl/blob/9a1907faa0c8733c20d98d15702e65a0b9757ee0/src/utils/general.jl#L331-L356