### PR TITLE
Minor fixes / QoL improvements

### DIFF
--- a/src/core/profile.jl
+++ b/src/core/profile.jl
@@ -151,12 +151,12 @@ function _isvalid(profile::Profile)
     end
 
     if profile.mode === :create
-        !_isempty(profile.node_from) &&
+        !isnothing(profile.node_from) &&
             @critical "`mode: create` cannot be used with `node_from`" profile = profile.name
-        _isempty(profile.node_to) || @critical "`mode: create` must specify `node_to`" profile = profile.name
+        isnothing(profile.node_to) && @critical "`mode: create` must specify `node_to`" profile = profile.name
     elseif profile.mode === :destroy
-        !_isempty(profile.node_to) && @critical "`mode: destroy` cannot be used with `node_to`" profile = profile.name
-        _isempty(profile.node_from) || @critical "`mode: destroy` must specify `node_from`" profile = profile.name
+        !isnothing(profile.node_to) && @critical "`mode: destroy` cannot be used with `node_to`" profile = profile.name
+        isnothing(profile.node_from) && @critical "`mode: destroy` must specify `node_from`" profile = profile.name
     end
 
     if !(profile.mode in [:fixed, :create, :destroy, :ranged])

--- a/src/core/profile.jl
+++ b/src/core/profile.jl
@@ -144,9 +144,10 @@ function _isvalid(profile::Profile)
         @critical "<carrier> could not be detected correctly" profile = profile.name
     end
 
-    if (profile.mode === :create) || (profile.mode === :destroy)
-        !_isempty(profile.lb) && (@warn "Setting <lb> is ignored" profile = profile.name mode = profile.mode)
-        !_isempty(profile.ub) && (@warn "Setting <ub> is ignored" profile = profile.name mode = profile.mode)
+    if profile.mode !== :ranged
+        !_isempty(profile.lb) && (@critical "Using `lb` requires `mode: ranged`" profile = profile.name)
+    elseif profile.mode === :fixed
+        !_isempty(profile.ub) && (@critical "Cannot use `ub` with `mode: fixed`" profile = profile.name)
     end
 
     if profile.mode === :create

--- a/src/core/profile.jl
+++ b/src/core/profile.jl
@@ -149,6 +149,15 @@ function _isvalid(profile::Profile)
         !_isempty(profile.ub) && (@warn "Setting <ub> is ignored" profile = profile.name mode = profile.mode)
     end
 
+    if profile.mode === :create
+        !_isempty(profile.node_from) &&
+            @critical "`mode: create` cannot be used with `node_from`" profile = profile.name
+        _isempty(profile.node_to) || @critical "`mode: create` must specify `node_to`" profile = profile.name
+    elseif profile.mode === :destroy
+        !_isempty(profile.node_to) && @critical "`mode: destroy` cannot be used with `node_to`" profile = profile.name
+        _isempty(profile.node_from) || @critical "`mode: destroy` must specify `node_from`" profile = profile.name
+    end
+
     if !(profile.mode in [:fixed, :create, :destroy, :ranged])
         @critical "Invalid <mode>" profile = profile.name
     end

--- a/src/templates/functions/validate.jl
+++ b/src/templates/functions/validate.jl
@@ -76,6 +76,7 @@ function _build_template_function_validate(template::CoreTemplate)
             __parameters__ = __virtual__._parameters
             __model__ = __virtual__.model
             this = __virtual__
+            has_addon(str::String) = haskey(internal(this.model).input.addons, str)
 
             __valid__ = true
             try

--- a/src/templates/parse.jl
+++ b/src/templates/parse.jl
@@ -324,6 +324,19 @@ function _parse_noncore!(model::JuMP.Model, description::Dict{String, Any}, cnam
     type = pop!(description[cname], "type")
     template = _require_template(model, type)
 
+    # Extract tags, if there are any.
+    if "tags" in keys(description[cname])
+        model_tags = internal(model).model.tags
+        tags = pop!(description[cname], "tags")
+        tags = tags isa String ? [tags] : tags
+        for tag in tags
+            if !haskey(model_tags, tag)
+                model_tags[tag] = Vector{String}()
+            end
+            push!(model_tags[tag], cname)
+        end
+    end
+
     # Remember its name and type properly, before that is lost due to flattening, by constructing a Virtual.
     internal(model).model.components[cname] = Virtual(;
         model,


### PR DESCRIPTION
Fixes #91 (better validation for `mode: create/destroy` Profiles and `node_from/to`)

Fixes #92 (allow setting `ub` to limit `mode: create/destroy` Profiles; setting `lb` will now abort instead of ignoring it)

Fixes #93 (allow checking whether an addon is present in the `validate` function of a template using `@check has_addon("SomeAddon")`)

Fixes #94 (tags added to a component that is based on a template are now properly detected; this allows, e.g., tagging a `type: CustomCHP` component with `tags: CHP`, which allows the standard CHP addon to pick it up and modify it)

---

Note: The huge diff in `con_value_bounds` is just removing the `if` and unindenting the contained code (no actually changes). The check for `ranged` is not necessary anymore, since improper combination of a bound and mode is detected in `isvalid`.