### PR TITLE
Manually create IDs for RGFs ...

### DIFF
--- a/src/templates/functions/finalize.jl
+++ b/src/templates/functions/finalize.jl
@@ -7,11 +7,13 @@ function _build_template_function_finalize(template::CoreTemplate)
     # Get code from "finalize" and remove trailing newline.
     code = chomp(template.yaml["functions"]["finalize"])
 
+    rgf_id = Tuple(reinterpret(UInt32, SHA.sha1(chomp(code))))
+
     # Parse the code into an expression.
     code_ex = Meta.parse("""begin\n$(code)\nend"""; filename="$(template.name).iesopt.template.yaml")
 
     # Convert into a proper function.
-    template.functions[:finalize] = @RuntimeGeneratedFunction(
+    template.functions[:finalize] = _compile_rgf(
         :(function (__virtual__::Virtual)
             __template_name__ = $(template).name
             __parameters__ = __virtual__._parameters
@@ -27,7 +29,8 @@ function _build_template_function_finalize(template::CoreTemplate)
                 rethrow(e)
             end
             return nothing
-        end)
+        end);
+        id=rgf_id,
     )
 
     return nothing

--- a/src/templates/functions/functions.jl
+++ b/src/templates/functions/functions.jl
@@ -1,3 +1,20 @@
+function _compile_rgf(ex; id::Tuple, opaque_closures::Bool=true)
+    cache_tag = getfield(@__MODULE__, Symbol("#_RGF_ModTag"))
+    context_tag = getfield(@__MODULE__, Symbol("#_RGF_ModTag"))
+
+    def = RuntimeGeneratedFunctions.splitdef(ex)
+    args = RuntimeGeneratedFunctions.normalize_args(get(def, :args, Symbol[]))
+
+    body = def[:body]
+    if opaque_closures
+        body = RuntimeGeneratedFunctions.closures_to_opaque(body)
+    end
+
+    cached_body = RuntimeGeneratedFunctions._cache_body(cache_tag, id, body)
+
+    return RuntimeGeneratedFunctions.RuntimeGeneratedFunction{Tuple(args), cache_tag, context_tag, id}(cached_body)
+end
+
 include("prepare.jl")
 include("validate.jl")
 include("finalize.jl")

--- a/src/templates/functions/prepare.jl
+++ b/src/templates/functions/prepare.jl
@@ -7,11 +7,13 @@ function _build_template_function_prepare(template::CoreTemplate)
     # Get code from "prepare" and remove trailing newline.
     code = chomp(template.yaml["functions"]["prepare"])
 
+    rgf_id = Tuple(reinterpret(UInt32, SHA.sha1(chomp(code))))
+
     # Parse the code into an expression.
     code_ex = Meta.parse("""begin\n$(code)\nend"""; filename="$(template.name).iesopt.template.yaml")
 
     # Convert into a proper function.
-    template.functions[:prepare] = @RuntimeGeneratedFunction(
+    template.functions[:prepare] = _compile_rgf(
         :(function (__virtual__::Virtual)
             __template_name__ = $(template).name
             __parameters__ = __virtual__._parameters
@@ -27,7 +29,8 @@ function _build_template_function_prepare(template::CoreTemplate)
                 rethrow(e)
             end
             return nothing
-        end)
+        end);
+        id=rgf_id,
     )
 
     return nothing

--- a/src/templates/functions/validate.jl
+++ b/src/templates/functions/validate.jl
@@ -66,11 +66,13 @@ function _build_template_function_validate(template::CoreTemplate)
     # Get code from "validate" and remove trailing newline.
     code = chomp(template.yaml["functions"]["validate"])
 
+    rgf_id = Tuple(reinterpret(UInt32, SHA.sha1(chomp(code))))
+
     # Parse the code into an expression.
     code_ex = Meta.parse("""begin\n$(code)\nend"""; filename="$(template.name).iesopt.template.yaml")
 
     # Convert into a proper function.
-    template.functions[:validate] = @RuntimeGeneratedFunction(
+    template.functions[:validate] = _compile_rgf(
         :(function (__virtual__::Virtual)
             __template_name__ = $(template).name
             __parameters__ = __virtual__._parameters
@@ -88,7 +90,8 @@ function _build_template_function_validate(template::CoreTemplate)
                 rethrow(e)
             end
             return __valid__
-        end)
+        end);
+        id=rgf_id,
     )
 
     return nothing


### PR DESCRIPTION
… that may be cached, since that uses expression-to-string-to-sha1 internally which takes a long time.

This is related to this [question on discourse](https://discourse.julialang.org/t/custom-id-for-runtimegeneratedfunction/130129), triggered by an abnormally long time to run a (small) version of our TYNDP model. Most of that time can be traced back to making sure that cached `RuntimeGeneratedFunctions` are "unique" which is basically done by converting the `Expr` to a string and creating a key (for the cache) using the `sha1` of that. For "longer" functions in templates that takes a long time.

However, we start off with the code as string, and can "quickly" come up with our own hash-based key for that. This is now done in `_compile_rgf`, which is directly based on how the normal constructor works in [RuntimeGeneratedFunctions.jl](https://github.com/SciML/RuntimeGeneratedFunctions.jl/blob/49bab0340504c7c6a9a42bfd47c5e05d64018ddd/src/RuntimeGeneratedFunctions.jl#L54-L64).

## Impact

Timings using `HiGHS` to build and solve a 24 snapshot TYNDP example model, comparing to current main:

```console
# manual-rgf-cache
16.825734 seconds (43.33 M allocations: 2.396 GiB, 4.02% gc time, 48 lock conflicts, 397.58% compilation time: 7% of which was recompilation)
3.934461 seconds (19.64 M allocations: 1.060 GiB, 5.27% gc time, 26 lock conflicts)
4.082442 seconds (19.64 M allocations: 1.060 GiB, 6.26% gc time, 57 lock conflicts)

# main
17.492934 seconds (45.01 M allocations: 2.480 GiB, 3.30% gc time, 53 lock conflicts, 433.86% compilation time: 6% of which was recompilation)
13.228051 seconds (51.53 M allocations: 2.416 GiB, 6.10% gc time, 64 lock conflicts, 10.22% compilation time)
18.251285 seconds (58.44 M allocations: 2.470 GiB, 6.39% gc time, 60 lock conflicts, 0.35% compilation time)
```

Just run naively for the first three executions in one session with `@time`, but it already clearly shows the possible change. I expect this to improve if we better include all template-based functions in an example for precompilation.