### PR TITLE
SOS1 objective now properly accounts for fixed costs

### DIFF
--- a/src/core/decision/obj_sos.jl
+++ b/src/core/decision/obj_sos.jl
@@ -13,7 +13,13 @@ function _decision_obj_sos!(decision::Decision)
     decision.obj.sos = JuMP.AffExpr(0.0)
     if decision.mode === :sos1
         for i in eachindex(decision.var.sos1_value)
-            JuMP.add_to_expression!(decision.obj.sos, decision.var.sos1_value[i], decision.sos[i]["cost"])
+            if haskey(decision.sos[i], "fixed_cost")
+                JuMP.add_to_expression!(decision.obj.sos, decision.var.sos[i], decision.sos[i]["fixed_cost"])
+            end
+
+            if haskey(decision.sos[i], "cost")
+                JuMP.add_to_expression!(decision.obj.sos, decision.var.sos1_value[i], decision.sos[i]["cost"])
+            end
         end
     elseif decision.mode === :sos2
         for i in eachindex(decision.var.sos)


### PR DESCRIPTION
This pull request introduces an enhancement to the objective function construction logic for SOS1 decisions in the `src/core/decision/obj_sos.jl` file. The main change is the addition of support for an optional `"fixed_cost"` parameter in the SOS1 decision objects, allowing for more flexible cost modeling.

Enhancement to SOS1 objective function:

* Added logic to check for and include a `"fixed_cost"` from each SOS1 decision entry in the objective expression, improving support for fixed costs in SOS1 decisions.
* Ensured that the existing `"cost"` parameter is still incorporated for each SOS1 decision entry, maintaining previous behavior.