### PR TITLE
Allow overwriting component settings

### DIFF
--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -481,7 +481,6 @@ function parse!(
     # TODO: properly check necessity of deepcopy (especially when adding "components" and "load_components")
     isempty(addons) || @error "The `addons` keyword argument is not yet supported"
     isempty(carriers) || @error "The `carriers` keyword argument is not yet supported"
-    isempty(components) || @error "The `components` keyword argument is not yet supported"
     isempty(load_components) || @error "The `load_components` keyword argument is not yet supported"
 
     # Load the model specified by `filename`.

--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -4,8 +4,31 @@ include("sections/files.jl")
 include("sections/results.jl")
 include("sections/paths.jl")
 
+"""
+    _nest_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
+
+Return a nested `Dict{String, Any}` representation of `settings`
+expanding all `.` occurences in keys to another nesting level.
+
+This turns any of
+
+    Dict("a.b.c" => x, "a.d" => y)
+    (; a=(; b=(; c=x), d=y))
+    Dict("a" => Dict("b.c" => x, "d" => y))
+
+into
+
+    Dict{String, Any}(
+        "a" => Dict{String, Any}(
+            "b" => Dict{String, Any}(
+                "c" => x,
+            ),
+            "d" => y,
+        ),
+    )
+"""
 function _nest_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
-    return _merge_recursive((_nest_recursive(k, _nest_recursive(v)) for (k, v) in pairs(settings))...)
+    return _merge_recursive!((_nest_recursive(k, _nest_recursive(v)) for (k, v) in pairs(settings))...)
 end
 _nest_recursive(v) = v
 function _nest_recursive(key, settings)
@@ -17,8 +40,27 @@ function _nest_recursive(key, settings)
     end
 end
 
+"""
+    _flatten_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
+
+Return a flattened `Dict{String, Any}` representation of `settings`
+collapsing all nesting levels into `.`-separated keys.
+
+This turns any of
+
+    Dict("a.b.c" => x, "a.d" => y)
+    (; a=(; b=(; c=x), d=y))
+    Dict("a" => Dict("b.c" => x, "d" => y))
+
+into
+
+    Dict{String, Any}(
+        "a.b.c" => x,
+        "a.d" => y,
+    )
+"""
 function _flatten_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
-    return _merge_recursive((_flatten_recursive(k, _flatten_recursive(v)) for (k, v) in pairs(settings))...)
+    return _merge_recursive!((_flatten_recursive(k, _flatten_recursive(v)) for (k, v) in pairs(settings))...)
 end
 _flatten_recursive(value) = value
 function _flatten_recursive(key, settings::Union{AbstractDict, NamedTuple, Base.Pairs})
@@ -26,30 +68,55 @@ function _flatten_recursive(key, settings::Union{AbstractDict, NamedTuple, Base.
 end
 _flatten_recursive(key, value) = Dict{String, Any}(string(key) => value)
 
+"""
+    _nest_once(settings)
+
+Add one nesting level "at the end" of a flattened `Dict` settings.
+
+This turns
+
+    Dict{String, Any}(
+        "a.b.c" => x,
+        "a.d" => y,
+    )
+
+into
+
+    Dict{String, Any}(
+        "a.b" => Dict{String,Any}("c" => x),
+        "a" => Dict{String, Any}("d" => y),
+    )
+"""
 function _nest_once(settings)
-    return _merge_recursive((_nest_once(k, v) for (k, v) in pairs(settings))...)
+    return _merge_recursive!((_nest_once(k, v) for (k, v) in pairs(settings))...)
 end
 function _nest_once(key, value)
     k, v = rsplit(string(key), "."; limit=2)
     return Dict{String, Any}(string(k) => Dict{String, Any}(string(v) => value))
 end
 
-_merge_recursive(d::Dict...) = merge(_merge_recursive, d...)
-_merge_recursive(x...) = last(x)
+"""
+    _merge_recursive!(d::Dict...)
+
+Recursively merge all nesting levels of all `Dict`s in `d` into the first `Dict` in `d`.
+"""
+_merge_recursive!(d::Dict...) = merge!(_merge_recursive!, d...)
+_merge_recursive!(x...) = last(x)
 
 function _replace_config_from_user!(model::JuMP.Model)
     config = internal(model).input._tl_yaml["config"]
     kwargs = model.ext[:_iesopt_kwargs][:config]
     if !isempty(kwargs)
-        internal(model).input._tl_yaml["config"] = _merge_recursive(config, _nest_recursive(kwargs))
+        _merge_recursive!(config, _nest_recursive(kwargs))
     end
     return nothing
 end
 
-function _replace_components_from_user(model::JuMP.Model, description)
+function _replace_components_from_user!(description, model::JuMP.Model)
     kwargs = model.ext[:_iesopt_kwargs][:components]
     isempty(kwargs) && return description
-    return _merge_recursive(description, _nest_once(_flatten_recursive(kwargs)))
+    _merge_recursive!(description, _nest_once(_flatten_recursive(kwargs)))
+    return nothing
 end
 
 function _prepare_config_and_logger!(model::JuMP.Model)

--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -4,13 +4,10 @@ include("sections/files.jl")
 include("sections/results.jl")
 include("sections/paths.jl")
 
-function _replace_config_from_user(model::JuMP.Model)
-    isempty(model.ext[:_iesopt_kwargs][:config]) && return nothing
-    data = internal(model).input._tl_yaml["config"]
-
-    for (k, v) in model.ext[:_iesopt_kwargs][:config]
-        accessors = split(k, '.')
-        current = data
+function _replace_config_from_user!(config::Dict{String}, settings)
+    for (k, v) in pairs(settings)
+        accessors = split(string(k), '.')
+        current = config
         for (i, accessor) in enumerate(accessors)
             if i == length(accessors)
                 current[accessor] = v
@@ -21,8 +18,14 @@ function _replace_config_from_user(model::JuMP.Model)
     end
 end
 
+function _replace_config_from_user!(model::JuMP.Model)
+    config = internal(model).input._tl_yaml["config"]
+    kwargs = model.ext[:_iesopt_kwargs][:config]
+    return _replace_config_from_user!(config, kwargs)
+end
+
 function _prepare_config_and_logger!(model::JuMP.Model)
-    _replace_config_from_user(model)
+    _replace_config_from_user!(model)
 
     _prepare_config_general!(model)
 

--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -4,32 +4,52 @@ include("sections/files.jl")
 include("sections/results.jl")
 include("sections/paths.jl")
 
-function _replace_config_from_user!(config::Dict{String}, settings)
-    for (k, v) in pairs(settings)
-        accessors = split(string(k), '.')
-        current = config
-        for (i, accessor) in enumerate(accessors)
-            if i == length(accessors)
-                current[accessor] = v
-            else
-                current = get!(current, accessor, Dict{String, Any}())
-            end
-        end
+function _nest_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
+    return _merge_recursive((_nest_recursive(k, _nest_recursive(v)) for (k, v) in pairs(settings))...)
+end
+_nest_recursive(v) = v
+function _nest_recursive(key, settings)
+    if contains(string(key), ".")
+        k, v = rsplit(string(key), "."; limit=2)
+        return _nest_recursive(k, Dict{String, Any}(string(v) => settings))
+    else
+        return Dict{String, Any}(string(key) => settings)
     end
 end
+
+function _flatten_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
+    return _merge_recursive((_flatten_recursive(k, _flatten_recursive(v)) for (k, v) in pairs(settings))...)
+end
+_flatten_recursive(value) = value
+function _flatten_recursive(key, settings::Union{AbstractDict, NamedTuple, Base.Pairs})
+    return Dict{String, Any}(string(key, ".", k) => v for (k, v) in pairs(settings))
+end
+_flatten_recursive(key, value) = Dict{String, Any}(string(key) => value)
+
+function _nest_once(settings)
+    return _merge_recursive((_nest_once(k, v) for (k, v) in pairs(settings))...)
+end
+function _nest_once(key, value)
+    k, v = rsplit(string(key), "."; limit=2)
+    return Dict{String, Any}(string(k) => Dict{String, Any}(string(v) => value))
+end
+
+_merge_recursive(d::Dict...) = merge(_merge_recursive, d...)
+_merge_recursive(x...) = last(x)
 
 function _replace_config_from_user!(model::JuMP.Model)
     config = internal(model).input._tl_yaml["config"]
     kwargs = model.ext[:_iesopt_kwargs][:config]
-    return _replace_config_from_user!(config, kwargs)
+    if !isempty(kwargs)
+        internal(model).input._tl_yaml["config"] = _merge_recursive(config, _nest_recursive(kwargs))
+    end
+    return nothing
 end
 
-function _replace_components_from_user!(model::JuMP.Model)
-    config = internal(model).input._tl_yaml["components"]
+function _replace_components_from_user(model::JuMP.Model, description)
     kwargs = model.ext[:_iesopt_kwargs][:components]
-    for (component, settings) in kwargs
-        _replace_config_from_user!(config[component], settings)
-    end
+    isempty(kwargs) && return description
+    return _merge_recursive(description, _nest_once(_flatten_recursive(kwargs)))
 end
 
 function _prepare_config_and_logger!(model::JuMP.Model)

--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -24,6 +24,14 @@ function _replace_config_from_user!(model::JuMP.Model)
     return _replace_config_from_user!(config, kwargs)
 end
 
+function _replace_components_from_user!(model::JuMP.Model)
+    config = internal(model).input._tl_yaml["components"]
+    kwargs = model.ext[:_iesopt_kwargs][:components]
+    for (component, settings) in kwargs
+        _replace_config_from_user!(config[component], settings)
+    end
+end
+
 function _prepare_config_and_logger!(model::JuMP.Model)
     _replace_config_from_user!(model)
 

--- a/src/config/config.jl
+++ b/src/config/config.jl
@@ -8,7 +8,7 @@ include("sections/paths.jl")
     _nest_recursive(settings::Union{AbstractDict, NamedTuple, Base.Pairs})
 
 Return a nested `Dict{String, Any}` representation of `settings`
-expanding all `.` occurences in keys to another nesting level.
+expanding all `.` occurrences in keys to another nesting level.
 
 This turns any of
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -53,6 +53,10 @@ function _parse_model!(model::JuMP.Model, filename::String)
 
         # Fully flatten the model description before parsing.
         _flatten_model!(model, description)
+
+        # Replace component configs passed by the user as kwargs
+        _replace_components_from_user!(model)
+
         merge!(internal(model).aux._flattened_description, deepcopy(description))
 
         # Construct the objectives container & add all registered objectives.

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -55,7 +55,7 @@ function _parse_model!(model::JuMP.Model, filename::String)
         _flatten_model!(model, description)
 
         # Replace component configs passed by the user as kwargs
-        _replace_components_from_user!(model)
+        description = _replace_components_from_user(model, description)
 
         merge!(internal(model).aux._flattened_description, deepcopy(description))
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -55,7 +55,7 @@ function _parse_model!(model::JuMP.Model, filename::String)
         _flatten_model!(model, description)
 
         # Replace component configs passed by the user as kwargs
-        description = _replace_components_from_user(model, description)
+        _replace_components_from_user!(description, model)
 
         merge!(internal(model).aux._flattened_description, deepcopy(description))
 

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -2,6 +2,9 @@
 
 @testitem "01_basic_single_node" tags = [:examples] setup = [TestExampleModule] begin
     TestExampleModule.check(; obj=525.0)
+    # We can overwrite the settings of specific components.
+    # An increased CO2 price (100 -> 200) results in a higher objective value
+    TestExampleModule.check(; obj=675, components=Dict("co2_emissions" => Dict("cost" => 200)))
 end
 
 @testitem "02_advanced_single_node" tags = [:examples] setup = [TestExampleModule] begin

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -62,6 +62,11 @@ end
     # We can also overwrite the settings of components in nested templates.
     # Fixing the initial state results in a higher objective value.
     TestExampleModule.check(; obj=4402.8, components=Dict("group.bess.state" => Dict("state_initial" => 5)))
+    # Increasing the electricity cost further increases the objective value
+    TestExampleModule.check(;
+        obj=6604.1,
+        components=Dict("group" => Dict("bess.state.state_initial" => 5, "buy_elec.cost" => 150)),
+    )
 end
 
 @testitem "17_varying_connection_capacity" tags = [:examples] setup = [TestExampleModule] begin
@@ -265,6 +270,11 @@ end
 
     @test JuMP.value.(get_component(model, "tariff_power_consumption").var.value) ≈ 4.5738 atol = 1e-2
     @test sum(JuMP.value.(get_component(model, "ev").var.state)) ≈ 713.5135 atol = 1e-2
+
+    # Only considering the first half of the snapshots results in a lower objective value.
+    TestExampleModule.check(; obj=11.8378, config=Dict("optimization.snapshots.count" => 12))
+    # That's also true for the second half.
+    TestExampleModule.check(; obj=8.9575, config=Dict("optimization.snapshots" => (count=12, offset=12)))
 end
 
 @testitem "54_simple_roomtemperature" tags = [:examples] setup = [Dependencies, TestExampleModule] begin
@@ -285,6 +295,9 @@ end
 
     @test JuMP.value(get_component(model, "storage").var.state[1]) == 100
     @test sum(JuMP.value, get_component(model, "storage").exp.injection) == 0
+
+    # not requiring a final state reduces the objective value
+    TestExampleModule.check(; obj=-3.5926424306e+03, components=Dict("storage.state_final" => nothing))
 end
 
 @testitem "57_structured_global_parameters" tags = [:examples] setup = [Dependencies, TestExampleModule] begin

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -58,6 +58,10 @@ end
 
     @test sum(sp) ≈ -0.25 atol = 0.01
     @test sum(abs.(sp)) ≈ 4.75 atol = 0.01
+
+    # We can also overwrite the settings of components in nested templates.
+    # Fixing the initial state results in a higher objective value.
+    TestExampleModule.check(; obj=4402.8, components=Dict("group.bess.state" => Dict("state_initial" => 5)))
 end
 
 @testitem "17_varying_connection_capacity" tags = [:examples] setup = [TestExampleModule] begin


### PR DESCRIPTION
These changes allow to overwrite the config of components in `IESopt.run` using the `components` kwarg:

```julia
model = IESopt.run(
    "assets/examples/01_basic_single_node.iesopt.yaml";
    components=Dict("co2_emissions" => Dict("cost" => 200)),
)
```

This replaces the originial cost of `100` of the `co2_emissions` `Profile` in the config with cost of `200`.

**Note** that in contrast to the `config` and `parameters` kwarg, here we need a nested `Dict` where the keys of the outer `Dict` are the component names, and their corresponding values are `Dict`s with keys for the parameters to be overwritten with the respective values.
Since writing these nested `Dict`s can be a bit cumbersome, in Julia we can also use `NamedTuple`s instead.

```julia
model = IESopt.run(
    "assets/examples/01_basic_single_node.iesopt.yaml";
    components=Dict("co2_emissions" => (cost=200,)),
)
```

In order to allow modifying components inside a template too, I decided for now to call the component replacement code after component flatting. This way something like this is possible:

```julia
model = IESopt.run(
    "assets/examples/16_noncore_components.iesopt.yaml",
    components=Dict("group.bess.state" => Dict("state_initial" => 5)),
)
```

Here, `state` is a component in the `BESS` template component `bess` which is a component in the `SampleGroup` template component `group`.
If the component config replacement happened before component flattening, this would not be possible and the user could only modify parameters of the `SampleGroup` template with the `components` kwarg (which are `bess_size`, `bess_power`, `cop_default` and `real_efficiency_heatpump`).

So this provides more flexibility. However, I am not quite happy with that, because it is not 100% analogous to the `config` and `parameters` kwargs, where the user just actually overwrites the respective sections in the yaml config, and not something that only becomes available during parsing, if you know what I mean.

An alternative could be to have this `components` kwarg behave the same way as the others and hook into parsing pipeline before model flattening. This would make the last example above impossible. However, we could add an additional `flattened_components` kwarg (or similar) that does what `components` does now in this implementation.
I was not sure, whether this gets too complicated and which approach is better.

Let me know, what you think, @sstroemer 