### PR TITLE
Specialize the "amount" of results that are being extracted

### DIFF
--- a/src/config/sections/results.jl
+++ b/src/config/sections/results.jl
@@ -4,7 +4,19 @@ function _prepare_config_results!(model::JuMP.Model)
     @config(model, results) = Dict{String, Union{Symbol, Bool}}()
 
     # Enabled.
-    @config(model, results.enabled) = get(data, "enabled", !get(data, "disabled", false))::Bool
+    if haskey(data, "disabled")
+        @warn "The `disabled` entry in `results` is deprecated; use `enabled` instead"
+    end
+    results_enabled = get(data, "enabled", !get(data, "disabled", false))
+    if results_enabled === true
+        @warn "Passing `true` to `results.enabled` is deprecated; use `all`, or any other specific setting instead"
+        results_enabled = "all"
+    end
+    if results_enabled === false
+        @warn "Passing `false` to `results.enabled` is deprecated; use `none` instead"
+        results_enabled = "none"
+    end
+    @config(model, results.enabled) = Symbol(results_enabled)
 
     # Memory only.
     memory_only = get(data, "memory_only", true)::Bool

--- a/src/results/jld2/ResultsJLD2.jl
+++ b/src/results/jld2/ResultsJLD2.jl
@@ -8,6 +8,7 @@ module ResultsJLD2
 using ..IESopt:
     internal,
     @config,
+    Node,
     _result_fields,
     _CoreComponent,
     _CoreComponentResult,

--- a/src/results/results.jl
+++ b/src/results/results.jl
@@ -61,7 +61,7 @@ include("jld2/ResultsJLD2.jl")
 include("duckdb/ResultsDuckDB.jl")
 
 function _handle_result_extraction(model::JuMP.Model)
-    if @config(model, results.enabled, Bool)
+    if @config(model, results.enabled) != :none
         # TODO: include content of result config section
         if !JuMP.is_solved_and_feasible(model)
             @error "[optimize > results] Extracting results is only possible for a solved and feasible model"


### PR DESCRIPTION
This currently supports:

- `all`: the previous `true`
- `none`: the previous `false`
- `reduced`: does not extract reduced costs of variables and only extracts duals for stateless nodes (where the dual represents an energy price)

This still needs to be documented in the official docs.

Auto summary:

---

This pull request updates how the results configuration is handled and enhances the extraction of dual values in the results module. The main focus is to deprecate old configuration options, improve warnings for users, and provide more granular control over which dual values are extracted and stored.

Configuration and Deprecation Handling:

* Updated `_prepare_config_results!` to deprecate the use of `disabled` and boolean values for `results.enabled`, issuing warnings and mapping them to new symbolic values (`:all`, `:none`). This makes the configuration more explicit and future-proof.
* Changed the check for whether to extract results from a boolean to a symbolic value (`:none`) in `_handle_result_extraction`, aligning with the new configuration approach.

Results Extraction Logic:

* In `_convert_to_result`, extraction of reduced costs and shadow prices is now conditional on the value of `results.enabled`. Reduced costs for variables are only extracted if `results.enabled == :all`, and shadow prices for constraints are filtered to stateless nodes when `results.enabled == :reduced`. This allows more targeted extraction and avoids unnecessary computation.

Code Maintenance:

* Added `Node` to the imports in `ResultsJLD2.jl` to support the new logic for filtering constraint dual extraction.