### PR TITLE
Fix #114

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,12 +1,6 @@
 name: Documentation
 
-on: {}
-#   push:
-#     branches: [main]
-#     tags: '*'
-#   pull_request:
-#     types: [opened, synchronize, reopened]
-#   workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/DocumentationCleanup.yml
+++ b/.github/workflows/DocumentationCleanup.yml
@@ -3,9 +3,7 @@
 
 name: DocumenationCleanup
 
-on: {}
-#   pull_request:
-#     types: [closed]
+on: workflow_dispatch
 
 concurrency:
   group: doc-preview-cleanup


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows related to documentation. The main change is to simplify and clarify when these workflows are triggered by switching their activation to manual dispatch only.

Workflow trigger updates:

* Changed the `Documentation.yml` workflow to be triggered only by the `workflow_dispatch` event, removing all other triggers.
* Changed the `DocumentationCleanup.yml` workflow to be triggered only by the `workflow_dispatch` event, removing all other triggers.