### PR TITLE
Expressify attributes of Decision

### DIFF
--- a/src/core/decision/con_fixed.jl
+++ b/src/core/decision/con_fixed.jl
@@ -4,7 +4,7 @@
 to be added
 """
 function _decision_con_fixed!(decision::Decision)
-    if isnothing(decision.fixed_cost) || (decision.mode === :sos1)
+    if _isempty(decision.fixed_cost) || (decision.mode === :sos1)
         return
     end
 
@@ -19,7 +19,7 @@ function _decision_con_fixed!(decision::Decision)
     else
         decision.con.fixed = @constraint(
             model,
-            decision.var.value <= decision.var.fixed * decision.ub,
+            decision.var.value <= decision.var.fixed * access(decision.ub),
             base_name = make_base_name(decision, "fixed")
         )
     end

--- a/src/core/decision/obj_fixed.jl
+++ b/src/core/decision/obj_fixed.jl
@@ -5,7 +5,7 @@ to be added
 ```
 """
 function _decision_obj_fixed!(decision::Decision)
-    if isnothing(decision.fixed_cost) && decision.mode != :sos1
+    if _isempty(decision.fixed_cost) && decision.mode != :sos1
         return
     end
 
@@ -15,18 +15,18 @@ function _decision_obj_fixed!(decision::Decision)
     if decision.mode === :sos1
         for i in eachindex(decision.sos)
             if haskey(decision.sos[i], "fixed_cost")
-                if !isnothing(decision.fixed_cost)
+                if !_isempty(decision.fixed_cost)
                     @warn "Decision is overwriting global fixed_cost based on SOS1 local" decision = decision.name maxlog =
                         1
                 end
 
                 JuMP.add_to_expression!(decision.obj.fixed, decision.var.sos[i], decision.sos[i]["fixed_cost"])
-            elseif !isnothing(decision.fixed_cost)
-                JuMP.add_to_expression!(decision.obj.fixed, decision.var.sos[i], decision.fixed_cost)
+            elseif !_isempty(decision.fixed_cost)
+                JuMP.add_to_expression!(decision.obj.fixed, decision.var.sos[i], access(decision.fixed_cost))
             end
         end
     else
-        JuMP.add_to_expression!(decision.obj.fixed, decision.var.fixed, decision.fixed_cost)
+        JuMP.add_to_expression!(decision.obj.fixed, decision.var.fixed, access(decision.fixed_cost))
     end
 
     push!(internal(model).model.objectives["total_cost"].terms, decision.obj.fixed)

--- a/src/core/decision/obj_value.jl
+++ b/src/core/decision/obj_value.jl
@@ -8,12 +8,12 @@ Add the cost defined by the value of this `Decision` to the `model`:
 ```
 """
 function _decision_obj_value!(decision::Decision)
-    if isnothing(decision.cost) || (decision.mode === :sos1 || decision.mode === :sos2)
+    if _isempty(decision.cost) || (decision.mode === :sos1 || decision.mode === :sos2)
         return nothing
     end
 
     model = decision.model
-    decision.obj.value = decision.var.value * decision.cost
+    decision.obj.value = decision.var.value * access(decision.cost)
     push!(internal(model).model.objectives["total_cost"].terms, decision.obj.value)
 
     return nothing

--- a/src/core/decision/var_fixed.jl
+++ b/src/core/decision/var_fixed.jl
@@ -4,7 +4,7 @@
 to be added
 """
 function _decision_var_fixed!(decision::Decision)
-    if isnothing(decision.fixed_cost) || (decision.mode === :sos1)
+    if _isempty(decision.fixed_cost) || (decision.mode === :sos1)
         return
     end
 

--- a/src/core/decision/var_value.jl
+++ b/src/core/decision/var_value.jl
@@ -16,16 +16,18 @@ function _decision_var_value!(decision::Decision)
     )
 
     if decision.mode === :fixed
-        JuMP.fix(decision.var.value, decision.fixed_value)
+        JuMP.fix(decision.var.value, access(decision.fixed_value)::Float64)
     else
-        if !isnothing(decision.ub) && (decision.lb == decision.ub)
-            JuMP.fix(decision.var.value, decision.lb)
+        if !_isempty(decision.ub) && (access(decision.lb) === access(decision.ub))
+            JuMP.fix(decision.var.value, access(decision.lb))
         else
-            if !isnothing(decision.lb)
-                JuMP.set_lower_bound(decision.var.value, decision.lb)
+            if !_isempty(decision.lb)
+                # TODO: `lb` could be something else than a scalar, which would require doing a constraint here
+                JuMP.set_lower_bound(decision.var.value, access(decision.lb)::Float64)
             end
-            if !isnothing(decision.ub)
-                JuMP.set_upper_bound(decision.var.value, decision.ub)
+            if !_isempty(decision.ub)
+                # TODO: `ub` could be something else than a scalar, which would require doing a constraint here
+                JuMP.set_upper_bound(decision.var.value, access(decision.ub)::Float64)
             end
         end
     end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -568,13 +568,11 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
             # Convert to Symbol
             mode = Symbol(pop!(prop, "mode", :linear))
 
-            lb = pop!(prop, "lb", 0)
-            ub = pop!(prop, "ub", nothing)
-            cost = pop!(prop, "cost", nothing)
-
-            (lb isa AbstractString) && (lb = eval(Meta.parse(lb)))
-            (ub isa AbstractString) && (ub = eval(Meta.parse(ub)))
-            (cost isa AbstractString) && (cost = eval(Meta.parse(cost)))
+            lb = _convert_to_expression(model, pop!(prop, "lb", 0))
+            ub = _convert_to_expression(model, pop!(prop, "ub", nothing))
+            cost = _convert_to_expression(model, pop!(prop, "cost", nothing))
+            fixed_value = _convert_to_expression(model, pop!(prop, "fixed_value", nothing))
+            fixed_cost = _convert_to_expression(model, pop!(prop, "fixed_cost", nothing))
 
             # Initialize.
             components[name] = Decision(;
@@ -586,6 +584,8 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
                 lb,
                 ub,
                 cost,
+                fixed_value,
+                fixed_cost,
                 Dict(Symbol(k) => v for (k, v) in prop)...,
             )
             # elseif type == "Expression"

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -270,7 +270,7 @@ end
     model = TestExampleModule.check(; obj=2_532_909.2063)
 
     @test JuMP.value.(get_component(model, "pipeline.invest").var.value) ≈ 42.0 atol = 1e-2
-    @test get_component(model, "pipeline.invest").cost ≈ 60067.3621 atol = 1e-2
+    @test access(get_component(model, "pipeline.invest").cost) ≈ 60067.3621 atol = 1e-2
 end
 
 @testitem "56_final_state_decision_cyclic" tags = [:examples] setup = [Dependencies, TestExampleModule] begin


### PR DESCRIPTION
Fixes #62

---

This pull request refactors how decision variable properties are handled by replacing the previous optional scalar input types with a new `Expression` type and updating related logic throughout the codebase. This improves flexibility for defining bounds, costs, and fixed values, and ensures consistent handling of these properties. The changes also update parsing, validation, and test code to work with the new system.

**Core refactor: Decision variable property handling**

* Changed the types of `lb`, `ub`, `cost`, `fixed_value`, and `fixed_cost` in the `Decision` struct from optional scalar inputs to `Expression`, using a default expression constructor. This allows for more flexible and consistent handling of these properties. [[1]](diffhunk://#diff-6c6ff9efd3d30758bbac40b885c78e92a16f0cc62f9a7d7456d41dd877576c06L23-R33) [[2]](diffhunk://#diff-6c6ff9efd3d30758bbac40b885c78e92a16f0cc62f9a7d7456d41dd877576c06L42-R42) [[3]](diffhunk://#diff-6c6ff9efd3d30758bbac40b885c78e92a16f0cc62f9a7d7456d41dd877576c06L53-R53)
* Updated the parsing logic in `parser.jl` to convert input properties to `Expression` objects using `_convert_to_expression`, and to pass these to the `Decision` constructor. [[1]](diffhunk://#diff-5f4a0613c856b7762a58c6df717c2918a3f13bde7139d996bec2fe8280f53f69L571-R575) [[2]](diffhunk://#diff-5f4a0613c856b7762a58c6df717c2918a3f13bde7139d996bec2fe8280f53f69R587-R588)

**Validation and logic updates**

* Replaced checks using `isnothing` with `_isempty` and added use of the `access` function to retrieve values from `Expression` objects in all relevant validation and constraint/objective logic. This ensures correct behavior when properties are expressions rather than simple scalars. [[1]](diffhunk://#diff-6c6ff9efd3d30758bbac40b885c78e92a16f0cc62f9a7d7456d41dd877576c06L97-R114) [[2]](diffhunk://#diff-3a80aa33db739615a61ea3c2243ed6f8458928f716210cf22602398f0f6fbf1cL7-R7) [[3]](diffhunk://#diff-3a80aa33db739615a61ea3c2243ed6f8458928f716210cf22602398f0f6fbf1cL22-R22) [[4]](diffhunk://#diff-3dea98a6b334a166e5da282954a2e33741d036f0c40ba7bd21135d55fb5ed5d2L8-R8) [[5]](diffhunk://#diff-3dea98a6b334a166e5da282954a2e33741d036f0c40ba7bd21135d55fb5ed5d2L18-R29) [[6]](diffhunk://#diff-ebc70d160f925db1898c6157cfb88d777ae18507f35eb87b74dac40cb43d5ec4L11-R16) [[7]](diffhunk://#diff-00d7c466c791a8ccd4e8fc9eaf387ee5e0a476f1ed91a9049b008e7d39920016L7-R7) [[8]](diffhunk://#diff-6a6e7279ddd7867c693f0c9d7a9fd2c73534e2192b8e85ff9b9d7f6fa95acae6L19-R30)

**Test updates**

* Updated tests to use the `access` function when checking values of decision properties, ensuring compatibility with the new `Expression` type.