### PR TITLE
Allow accessing data within registered "files" using `get_file_data`

### DIFF
--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -363,6 +363,16 @@ function _getfromcsv(model::JuMP.Model, file::String, column::String)
     return @view df[get_T(model), column]
 end
 
+"""
+    get_file_data(model::JuMP.Model, str::String)
+
+Get data from a registered (CSV) file based on a string in the format "column@file".
+"""
+function get_file_data(model::JuMP.Model, str::String)
+    col, file = String.(split(str, "@"))
+    return _getfromcsv(model, file, col)
+end
+
 function _conv_S2NI(model::JuMP.Model, str::AbstractString)
     # This handles pure values like "2.0".
     val = tryparse(Float64, str)


### PR DESCRIPTION
This pull request introduces a new utility function to streamline data retrieval from CSV files using a concise string format. The main change is the addition of `get_file_data`, which improves usability when accessing column data from registered files.

**Utilities for CSV data access:**

* Added the `get_file_data(model::JuMP.Model, str::String)` function to allow fetching data from a CSV file using a string formatted as `"column@file"`, simplifying calls to `_getfromcsv`.