### PR TITLE
Call `_finalize` on expressified Decision fields (fix)

### DIFF
--- a/src/core/decision.jl
+++ b/src/core/decision.jl
@@ -173,6 +173,13 @@ include("decision/var_sos.jl")
 include("decision/var_value.jl")
 
 function _construct_variables!(decision::Decision)
+    # We need to finalize earlier than for other components, since the following function already use the fields
+    _finalize(decision.lb)
+    _finalize(decision.ub)
+    _finalize(decision.cost)
+    _finalize(decision.fixed_value)
+    _finalize(decision.fixed_cost)
+
     _decision_var_fixed!(decision)
     _decision_var_sos!(decision)
     _decision_var_value!(decision)


### PR DESCRIPTION
This pull request updates the variable construction process in the `Decision` component to ensure that key fields are finalized before they are used by subsequent functions. The main change is the addition of explicit calls to `_finalize` on several fields, which helps prevent issues related to uninitialized or incomplete data.

Initialization improvements:

* Added calls to `_finalize` for the `lb`, `ub`, `cost`, `fixed_value`, and `fixed_cost` fields in the `_construct_variables!` function to ensure these fields are fully prepared before being used by downstream logic.