### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/core/carrier.jl
+++ b/src/core/carrier.jl
@@ -20,7 +20,7 @@ but also enables modelling commodities that are not (treated as) representing so
 end
 
 @recompile_invalidations begin
-    Base.hash(carrier::Carrier) = hash(carrier.name)
+    Base.hash(carrier::Carrier, h::UInt) = hash(carrier.name, h)
 end
 
 """


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.