### PR TITLE
Implement extra_components keyword argument

### DIFF
--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -471,6 +471,7 @@ function parse!(
     carriers::Dict=_global_settings.carriers,
     components::Dict=_global_settings.components,
     load_components::Dict=_global_settings.load_components,
+    extra_components::Union{Nothing,Vector,DataFrames.DataFrame}=nothing,
     virtual_files::Dict{String, DataFrames.DataFrame}=Dict{String, DataFrames.DataFrame}(),
 )
     @nospecialize
@@ -487,6 +488,7 @@ function parse!(
         :carriers => deepcopy(carriers),
         :components => components,
         :load_components => load_components,
+        :extra_components => extra_components,
     )
 
     # TODO: properly check necessity of deepcopy (especially when adding "components" and "load_components")

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -455,7 +455,7 @@ Parse the model configuration from a specified file and update the given `JuMP.M
 - `filename::AbstractString`: The path to the configuration file. The file must have a `.iesopt.yaml` extension.
 
 # Keyword Arguments
-- `parameters::Union{Dict, Vector}`: Replacements for global model paramenters defined in `filename`.
+- `parameters::Union{Dict, Vector}`: Replacements for global model parameters defined in `filename`.
 - `config::Dict`: Replacements for parameters in the config section of `filename`.
     This can be a nested `Dict` or a "flat" version where levels are separated by `"."`.
     For example, to set the snapshots config of a Model, you could use any of the following

--- a/src/IESopt.jl
+++ b/src/IESopt.jl
@@ -190,6 +190,7 @@ Build, optimize, and return a model.
 - `filename::String`: The path to the top-level configuration file.
 
 # Keyword Arguments
+The keyword arguments are passed to [`IESopt.parse`](@ref).
 
 Keyword arguments are passed to the `generate!(...)` function.
 """
@@ -245,7 +246,7 @@ Generates an IESopt model from a given file and attaches an optimizer if necessa
 - `filename::String`: The path to the file containing the model definition.
 
 # Keyword Arguments
-To be documented.
+The keyword arguments are passed to [`IESopt.parse!`](@ref).
 
 # Returns
 - `model::JuMP.Model`: The generated IESopt model.
@@ -454,7 +455,23 @@ Parse the model configuration from a specified file and update the given `JuMP.M
 - `filename::AbstractString`: The path to the configuration file. The file must have a `.iesopt.yaml` extension.
 
 # Keyword Arguments
-To be documented.
+- `parameters::Union{Dict, Vector}`: Replacements for global model paramenters defined in `filename`.
+- `config::Dict`: Replacements for parameters in the config section of `filename`.
+    This can be a nested `Dict` or a "flat" version where levels are separated by `"."`.
+    For example, to set the snapshots config of a Model, you could use any of the following
+    - `config=Dict("optimization.snapshots.count" => 4, "optimization.snapshots.weights" => 0.25)`
+    - `config=Dict("optimization.snapshots" => Dict("count" => 4, "weights" => 0.25))`
+    - `config=Dict("optimization" => Dict("snapshots" => Dict("count" => 4, "weights" => 0.25)))`
+- `components::Dict`: Replacements for parameters in the components section of `filename`.
+    This can be used to overwrite individual component parameters,
+    like the initial state of a `Node` in a rolling horizon setup (`components=Dict("battery.state.state_initial" => 1)`),
+    or to disable individual components.
+- `extra_components::Union{Nothing, DataFrame, Vector{DataFrame}}`:
+    One or more DataFrames with extra components to be addad to the model.
+    Analogous to the CSV files in the load_components section of the config file, each row corresponds to a single component.
+- `virtual_files::Dict{String, DataFrame}`:
+    Additional "timeseries" `DataFrame`s that can be accessed in the config analogous to the CSV files set in the `config.files`
+    section of the config.
 
 # Returns
 - `Bool`: Returns `true` if the model was successfully parsed.
@@ -471,7 +488,7 @@ function parse!(
     carriers::Dict=_global_settings.carriers,
     components::Dict=_global_settings.components,
     load_components::Dict=_global_settings.load_components,
-    extra_components::Union{Nothing,Vector,DataFrames.DataFrame}=nothing,
+    extra_components::Union{Nothing, Vector, DataFrames.DataFrame}=nothing,
     virtual_files::Dict{String, DataFrames.DataFrame}=Dict{String, DataFrames.DataFrame}(),
 )
     @nospecialize

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -51,6 +51,9 @@ function _parse_model!(model::JuMP.Model, filename::String)
         # Parse potential external CSV files defining components.
         _parse_components_csv!(model, internal(model).input._tl_yaml, description)
 
+        # Parse potential external CSV files defining components.
+        _parse_extra_components_from_user!(description, model)
+
         # Fully flatten the model description before parsing.
         _flatten_model!(model, description)
 
@@ -653,9 +656,22 @@ function _parse_components_csv!(
         end
     end
 
+    global_parameters = internal(model).input.parameters
     for file in files_to_load
         df = _getfile(model, file; path=:components, slice=false)
-        global_parameters = internal(model).input.parameters
+        _parse_components_from_df!(description, df, global_parameters)
+    end
+end
+
+function _parse_extra_components_from_user!(description, model::JuMP.Model)
+    extra_components = model.ext[:_iesopt_kwargs][:extra_components]
+    isnothing(extra_components) && return nothing
+    global_parameters = internal(model).input.parameters
+    if extra_components isa DataFrames.AbstractDataFrame
+        _parse_components_from_df!(description, extra_components, global_parameters)
+        return nothing
+    end
+    for df in extra_components
         _parse_components_from_df!(description, df, global_parameters)
     end
 end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -333,7 +333,7 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
     @info "[parse] Creating and parameterizing $(length(description)) core components"
 
     components = internal(model).model.components
-	core_components = ["Connection", "Decision", "Node", "Profile", "Unit"]
+    core_components = ["Connection", "Decision", "Node", "Profile", "Unit"]
 
     model_tags = internal(model).model.tags
     for type in core_components
@@ -348,7 +348,7 @@ function _parse_components!(model::JuMP.Model, @nospecialize(description::Dict{S
         end
 
         type = pop!(prop, "type")
-		type ∈ core_components || error("Non core components cannot be constructed.")
+        type ∈ core_components || error("Non core components cannot be constructed.")
         name = desc
 
         if !has_invalid_component_name && !_is_valid_component_name(name)
@@ -653,45 +653,66 @@ function _parse_components_csv!(
         end
     end
 
-    warnlogcount = 0
     for file in files_to_load
         df = _getfile(model, file; path=:components, slice=false)
+        global_parameters = internal(model).input.parameters
+        _parse_components_from_df!(description, df, global_parameters)
+    end
+end
 
-        # todo: this is probably super inefficient
-        for row in eachrow(df)
-            name = row.name
+function _parse_components_from_df!(description, df, global_parameters)
+    for row in DataFrames.eachrow(df)
+        if haskey(description, row.name)
+            @critical "[parse] Duplicate component entry detected" component = row.name
+        end
+        description[row.name] = _parse_component_description(row, global_parameters)
+    end
+end
 
-            if haskey(description, name)
-                @critical "[parse] Duplicate component entry detected" file component = name
-            end
-            props = row[DataFrames.Not(:name)]
-
-            dict_entries = Vector{String}()
-            sizehint!(dict_entries, length(props))
-            for (k, v) in zip(names(props), values(props))
-                if !ismissing(v)
-                    if !isnothing(internal(model).input.parameters) && v[1] == '<'
-                        # This is a parameter that we need to replace.
-                        push!(dict_entries, "$k: $(internal(model).input.parameters[v[2:(end - 1)]])")
-                    else
-                        push!(dict_entries, "$k: $v")
-                    end
-                else
-                    # Is this a global parameter that we should fill in automatically?
-                    if !isnothing(internal(model).input.parameters) && haskey(internal(model).input.parameters, k)
-                        if warnlogcount == 0
-                            @warn "[parse] You left a field empty in a CSV component definition file that corresponds to a global parameter. Automatic replacement is happening. Did you really intend this?" component =
-                                name property = k
-                            warnlogcount += 1
-                        end
-                        push!(dict_entries, "$k: $(internal(model).input.parameters[k])")
-                    end
-
-                    # We skip values that are "just missing".
-                end
-            end
-
-            description[name] = YAML.load(join(dict_entries, "\n"); dicttype=Dict{String, Any})
+function _parse_component_description(container, global_parameters)
+    description = Dict{String, Any}()
+    sizehint!(description, length(container) - 1)
+    for (name, value) in pairs(container)
+        if Symbol(name) !== :name
+            _set_component_parameter!(description, name, value, global_parameters)
         end
     end
+    return description
+end
+
+function _set_component_parameter!(dict, name, value, ::Any)
+    dict[string(name)] = value
+    return nothing
+end
+function _set_component_parameter!(dict, name, value::AbstractString, global_parameters)
+    if startswith(value, "<") && endswith(value, ">")
+        parameter_name = value[2:(end - 1)]
+        dict[string(name)] = global_parameters[parameter_name]
+    elseif startswith(value, "{") && endswith(value, "}")
+        dict[string(name)] = YAML.load(value; dicttype=Dict{String, Any})
+    else
+        dict[string(name)] = string(value)
+    end
+end
+function _set_component_parameter!(dict, name, value::AbstractString, ::Nothing)
+    dict[string(name)] = string(value)
+    return nothing
+end
+function _set_component_parameter!(::Any, ::Any, ::Missing, ::Nothing) end
+function _set_component_parameter!(dict, name, ::Missing, global_parameters)
+    key = string(name)
+    if haskey(global_parameters, key)
+        @warn(
+            string(
+                "[parse] You left a field empty in a component definition. ",
+                "It corresponds to a global parameter. ",
+                "Automatic replacement is happening. ",
+                "Did you really intend this?",
+            ),
+            property = key,
+            maxlog = 1
+        )
+        dict[key] = global_parameters[key]
+    end
+    return nothing
 end

--- a/src/utils/testing.jl
+++ b/src/utils/testing.jl
@@ -1,6 +1,7 @@
 # Setup snippets, etc. for testing.
 @testsnippet Dependencies begin
     import IESopt.Assets
+    import IESopt.DataFrames
     import IESopt.JuMP
 end
 

--- a/test/src/examples.jl
+++ b/test/src/examples.jl
@@ -35,8 +35,21 @@ end
     TestExampleModule.check(; obj=2015.6)
 end
 
-@testitem "09_csv_only" tags = [:examples] setup = [TestExampleModule] begin
+@testitem "09_csv_only" tags = [:examples] setup = [Dependencies, TestExampleModule] begin
     TestExampleModule.check(; obj=667437.8)
+
+    # we can pass more components in tables using extra_components
+    extra_units = DataFrames.DataFrame(;
+        name="extra_wind",
+        type="Unit",
+        inputs="{'wind': 'wind'}",
+        outputs="{'electricity': 'node1'}",
+        conversion="1 wind -> 1 electricity",
+        capacity="3 out:electricity",
+        availability_factor="ex07_plant_wind_availability_factor@data",
+    )
+    # additional wind reduces the objective function
+    TestExampleModule.check(; extra_components=extra_units, obj=190534.75)
 end
 
 @testitem "10_basic_load_shedding" tags = [:examples] setup = [TestExampleModule] begin
@@ -236,6 +249,22 @@ end
     @test JuMP.termination_status(model) == JuMP.INFEASIBLE
     # There is no component with "storage" in its name in the model
     @test !any(contains("storage"), keys(internal(model).model.components))
+
+    # We can add additional components defined as templates with a table in `extra_components`
+    # Adding a "different" storage this way makes the model feasible again.
+    storage_df = DataFrames.DataFrame(; name="other_storage", type="CustomStorage", connect_to="grid")
+    TestExampleModule.check(; components=Dict("storage.disabled" => true), extra_components=storage_df, obj=981.17)
+
+    # We can also pass multiple tables to `extra_components`.
+    # Additional demand increases the objective value even with additional storage.
+    demands_df = DataFrames.DataFrame(;
+        name=["extra_demand$i" for i in 1:3],
+        type="Profile",
+        carrier="electricity",
+        node_from="grid",
+        value=0.1,
+    )
+    TestExampleModule.check(; extra_components=[storage_df, demands_df], obj=1057.28)
 end
 
 @testitem "49_csv_format" tags = [:examples] setup = [Dependencies, TestExampleModule] begin


### PR DESCRIPTION
This allows to pass additional components in one or multiple `DataFrame`s to a model similar to to the `load_components` section in the config yaml. A single `DataFrame` as well as a `Vector{DataFrame}` are allowed:

```julia
IESopt.run(...; extra_components=df)
IESopt.run(...; extra_components=[df1, df2, ...])
```

In contrast to the `components` kwarg. The components in `extra_components` are parsed before model flattening. Hence, this also supports composite components defined in templates.